### PR TITLE
Add function to create simulating functions from ODE RHS

### DIFF
--- a/nasap/simulation/__init__.py
+++ b/nasap/simulation/__init__.py
@@ -1,1 +1,2 @@
 from .gillespie import Gillespie
+from .simulating_func import make_simulating_func_from_ode_rhs

--- a/nasap/simulation/tests/test_simulating_func.py
+++ b/nasap/simulation/tests/test_simulating_func.py
@@ -1,0 +1,69 @@
+import numpy as np
+import numpy.typing as npt
+import pytest
+from scipy.integrate import solve_ivp
+
+from nasap.simulation import make_simulating_func_from_ode_rhs
+
+
+def test_one_reaction():
+    # A -> B
+    def ode_rhs(t: float, y: npt.NDArray, k: float) -> npt.NDArray:
+        return np.array([-k * y[0], k * y[0]])
+
+    simulating_func = make_simulating_func_from_ode_rhs(ode_rhs)
+
+    t = np.logspace(-3, 1, 12)
+    y0 = np.array([1, 0])
+    k = 1
+
+    sol = solve_ivp(ode_rhs, (t[0], t[-1]), y0, args=(k,), dense_output=True)
+    expected = sol.sol(t)
+
+    y = simulating_func(t, y0, k)
+
+    np.testing.assert_allclose(y, expected)
+
+
+def test_two_reactions():
+    # A -> B -> C
+    def ode_rhs(t: float, y: npt.NDArray, k1: float, k2: float) -> npt.NDArray:
+        return np.array([-k1 * y[0], k1 * y[0] - k2 * y[1], k2 * y[1]])
+
+    simulating_func = make_simulating_func_from_ode_rhs(ode_rhs)
+
+    t = np.logspace(-3, 1, 12)
+    y0 = np.array([1, 0, 0])
+    k1 = 1
+    k2 = 1
+
+    sol = solve_ivp(ode_rhs, (t[0], t[-1]), y0, args=(k1, k2), dense_output=True)
+    expected = sol.sol(t)
+
+    y = simulating_func(t, y0, k1, k2)
+
+    np.testing.assert_allclose(y, expected)
+
+
+def test_reversible_reaction():
+    # A <-> B
+    def ode_rhs(t: float, y: npt.NDArray, k1: float, k2: float) -> npt.NDArray:
+        return np.array([-k1 * y[0] + k2 * y[1], k1 * y[0] - k2 * y[1]])
+    
+    simulating_func = make_simulating_func_from_ode_rhs(ode_rhs)
+
+    t = np.logspace(-3, 1, 12)
+    y0 = np.array([1, 0])
+    k1 = 1
+    k2 = 1
+
+    sol = solve_ivp(ode_rhs, (t[0], t[-1]), y0, args=(k1, k2), dense_output=True)
+    expected = sol.sol(t)
+
+    y = simulating_func(t, y0, k1, k2)
+
+    np.testing.assert_allclose(y, expected)
+
+
+if __name__ == "__main__":
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new function for creating simulating functions from ODE right-hand side functions and includes corresponding tests. The most important changes are the addition of the new function, its integration into the module, and the creation of tests to ensure its correctness.

### New Functionality:
* [`nasap/simulation/simulating_func.py`](diffhunk://#diff-66eab44522c5e88fb61c43079e16aa0995508bae20c9192f084c39a94da0b973R1-R48): Added the `make_simulating_func_from_ode_rhs` function, which generates a simulating function from an ODE right-hand side function. This function allows users to simulate ODEs by providing time points, initial values, and parameters.

### Integration:
* [`nasap/simulation/__init__.py`](diffhunk://#diff-53458123f84f68b4a0665a314b7f3b7480f183f0e0dfc04b261b13f2f99b079aR2): Imported the newly created `make_simulating_func_from_ode_rhs` function to make it accessible from the module's top level.

### Testing:
* [`nasap/simulation/tests/test_simulating_func.py`](diffhunk://#diff-70bb6146ab8aa36ad74bdf5e66d166d11f693754e828caa379a781809cc52d26R1-R69): Added tests for the new `make_simulating_func_from_ode_rhs` function, including scenarios for single reactions, multiple reactions, and reversible reactions. These tests ensure that the function works correctly by comparing its output to the expected results from `solve_ivp`.