### PR TITLE
Add objective function creation utility

### DIFF
--- a/nasap/fitting/__init__.py
+++ b/nasap/fitting/__init__.py
@@ -1,1 +1,2 @@
+from .objective_func import make_objective_func_from_simulating_func
 from .rss import calc_simulation_rss

--- a/nasap/fitting/objective_func.py
+++ b/nasap/fitting/objective_func.py
@@ -1,0 +1,57 @@
+from collections.abc import Callable, Mapping
+from typing import Concatenate
+
+import numpy.typing as npt
+
+from .rss import calc_simulation_rss
+
+
+# TODO: Add examples
+def make_objective_func_from_simulating_func(
+        tdata: npt.NDArray, ydata: npt.NDArray, 
+        simulating_func: Callable[
+            Concatenate[npt.NDArray, npt.NDArray, ...], npt.NDArray],
+        y0: npt.NDArray,
+        ) -> Callable[[npt.NDArray], float]:
+    """Make an objective function from a simulating function.
+    
+    Parameters
+    ----------
+    tdata : npt.NDArray, shape (n,)
+        Time points of the data.
+    ydata : npt.NDArray, shape (n, m)
+        Data to be compared with the simulation.
+        NaN values are ignored.
+    simulating_func : Callable
+        Function that simulates the system. 
+        
+            ``simulating_func(t, y0, *args, **kwargs) -> y``
+        
+        where ``t`` is a 1-D array with shape (n,), ``y0`` is a 1-D
+        array with shape (m,), ``args`` and ``kwargs`` are additional
+        arguments and keyword arguments for the simulation, and ``y``
+        is a 2-D array with shape (n, m). Note that all the parameters
+        of the simulation will be passed as ``*args``, i.e., keyword-only
+        arguments are not supported.
+    y0 : npt.NDArray, shape (m,)
+        Initial conditions.
+
+    Returns
+    -------
+    Callable
+        The objective function that calculates the residual sum of squares
+        (RSS) between the data and the simulation for a given set of parameters.
+        It has the signature
+        
+            ``objective_func(param_values) -> rss``
+        
+        where ``param_values`` is a 1-D array with shape (p,) and ``rss`` is
+        the residual sum of squares (float). The parameters should be passed
+        in the same order as they are expected by the simulation function.
+    """
+
+    def objective_func(param_values: npt.NDArray) -> float:
+        rss = calc_simulation_rss(tdata, ydata, simulating_func, y0, *param_values)
+        return rss
+    
+    return objective_func

--- a/nasap/fitting/tests/test_objective_func.py
+++ b/nasap/fitting/tests/test_objective_func.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+from scipy.optimize import differential_evolution
+
+from nasap.fitting import make_objective_func_from_simulating_func
+from nasap.simulation import make_simulating_func_from_ode_rhs
+
+# TODO: Add more tests
+
+
+def test_use_for_differential_evolution():
+    # A -> B
+    def ode_rhs(t, y, k):
+        return np.array([-k * y[0], k * y[0]])
+
+    simulating_func = make_simulating_func_from_ode_rhs(ode_rhs)
+
+    tdata = np.logspace(-3, 1, 12)
+    y0 = np.array([1, 0])
+    k = 1
+    ydata = simulating_func(tdata, y0, k)
+
+    objective_func = make_objective_func_from_simulating_func(
+        tdata, ydata, simulating_func, y0)
+
+    result = differential_evolution(objective_func, [(0, 10)])
+
+    assert np.isclose(result.fun, 0.0)
+    assert np.isclose(result.x, k)
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new feature to create an objective function from a simulating function and includes corresponding tests. The main changes involve adding a new function in the `objective_func` module, updating the `__init__.py` to import this function, and adding a test case for it.

New feature implementation:

* [`nasap/fitting/objective_func.py`](diffhunk://#diff-2cd6ba542a533e521a1eaa210666937f7289cfc6c9aa5690fa7e9f47f4c1821cR1-R57): Added the `make_objective_func_from_simulating_func` function, which constructs an objective function from a simulating function. This function calculates the residual sum of squares (RSS) between the data and the simulation for a given set of parameters.

Codebase updates:

* [`nasap/fitting/__init__.py`](diffhunk://#diff-19caa9c48dea00d6fa943885bb770b1c7869f281ffd2dd7a3e7d556efe6e782eR1): Imported the new `make_objective_func_from_simulating_func` function.

Testing:

* [`nasap/fitting/tests/test_objective_func.py`](diffhunk://#diff-9c863bbafd0801cd4f1ae0088ff47883f178c12f0e5bc5ba864c4f4dbeb474dbR1-R33): Added a test case to verify the functionality of the `make_objective_func_from_simulating_func` function using differential evolution optimization.