### PR TITLE
Fix output array shape of simulation functions

### DIFF
--- a/nasap/simulation/simulating_func.py
+++ b/nasap/simulation/simulating_func.py
@@ -62,6 +62,6 @@ def make_simulating_func_from_ode_rhs(
             ode_rhs_with_fixed_parameters, (t[0], t[-1]), y0,
             dense_output=True)
 
-        return sol.sol(t)
+        return sol.sol(t).T
 
     return simulating_func

--- a/nasap/simulation/tests/test_simulating_func.py
+++ b/nasap/simulation/tests/test_simulating_func.py
@@ -18,10 +18,11 @@ def test_one_reaction():
     k = 1
 
     sol = solve_ivp(ode_rhs, (t[0], t[-1]), y0, args=(k,), dense_output=True)
-    expected = sol.sol(t)
+    expected = sol.sol(t).T
 
     y = simulating_func(t, y0, k)
 
+    assert y.shape == (len(t), len(y0))
     np.testing.assert_allclose(y, expected)
 
 
@@ -38,10 +39,11 @@ def test_two_reactions():
     k2 = 1
 
     sol = solve_ivp(ode_rhs, (t[0], t[-1]), y0, args=(k1, k2), dense_output=True)
-    expected = sol.sol(t)
+    expected = sol.sol(t).T
 
     y = simulating_func(t, y0, k1, k2)
 
+    assert y.shape == (len(t), len(y0))
     np.testing.assert_allclose(y, expected)
 
 
@@ -58,10 +60,11 @@ def test_reversible_reaction():
     k2 = 1
 
     sol = solve_ivp(ode_rhs, (t[0], t[-1]), y0, args=(k1, k2), dense_output=True)
-    expected = sol.sol(t)
+    expected = sol.sol(t).T
 
     y = simulating_func(t, y0, k1, k2)
 
+    assert y.shape == (len(t), len(y0))
     np.testing.assert_allclose(y, expected)
 
 


### PR DESCRIPTION
This pull request includes changes to the `nasap/simulation/simulating_func.py` and `nasap/simulation/tests/test_simulating_func.py` files to ensure that the output of the `solve_ivp` function is transposed. Additionally, assertions have been added to verify the shape of the output.

Changes to `simulating_func.py`:

* Transposed the output of `sol.sol(t)` in the `ode_rhs_with_fixed_parameters` function to ensure correct output shape.

Changes to `test_simulating_func.py`:

* Transposed the output of `sol.sol(t)` in the `ode_rhs` function to match the expected output shape.
* Added an assertion to verify the shape of `y` in the `ode_rhs` function.
* Transposed the output of `sol.sol(t)` in the `ode_rhs` function with two parameters `k1` and `k2` to match the expected output shape.
* Added an assertion to verify the shape of `y` in the `ode_rhs` function with two parameters `k1` and `k2`.
* Transposed the output of `sol.sol(t)` in another instance of the `ode_rhs` function with two parameters `k1` and `k2` to match the expected output shape.
* Added an assertion to verify the shape of `y` in another instance of the `ode_rhs` function with two parameters `k1` and `k2`.