### PR TITLE
Add objective function utility for lmfit minimizer

### DIFF
--- a/nasap/fitting/lmfit/__init__.py
+++ b/nasap/fitting/lmfit/__init__.py
@@ -1,0 +1,1 @@
+from .objective_func import *

--- a/nasap/fitting/lmfit/objective_func.py
+++ b/nasap/fitting/lmfit/objective_func.py
@@ -1,0 +1,100 @@
+from collections.abc import Callable
+from typing import Concatenate
+
+import numpy.typing as npt
+from lmfit import Parameters
+
+from ..rss import calc_simulation_rss
+
+
+def make_objective_func_for_lmfit_minimizer(
+        tdata: npt.NDArray, ydata: npt.NDArray, 
+        simulating_func: Callable[
+            Concatenate[npt.NDArray, npt.NDArray, ...], npt.NDArray],
+        y0: npt.NDArray,
+        ) -> Callable[[npt.NDArray], float]:
+    """Make an objective function for the `lmfit.Minimizer` class from 
+    a simulating function.
+
+    Resulting objective function can be used as the ``userfcn`` parameter
+    of the `lmfit.Minimizer` class.
+    
+    Parameters
+    ----------
+    tdata : npt.NDArray, shape (n,)
+        Time points of the data.
+    ydata : npt.NDArray, shape (n, m)
+        Data to be compared with the simulation.
+        NaN values are ignored.
+    simulating_func : Callable
+        Function that simulates the system. 
+        
+            ``simulating_func(t, y0, *args, **kwargs) -> y``
+        
+        where ``t`` is a 1-D array with shape (n,), ``y0`` is a 1-D
+        array with shape (m,), ``args`` and ``kwargs`` are additional
+        arguments and keyword arguments for the simulation, and ``y``
+        is a 2-D array with shape (n, m). Note that all the parameters
+        of the simulation will be passed as ``*kwargs``, i.e., 
+        positional-only arguments are not supported.
+    y0 : npt.NDArray, shape (m,)
+        Initial conditions.
+
+    Returns
+    -------
+    Callable
+        The objective function that calculates the residual sum of squares
+        (RSS) between the data and the simulation for a given set of 
+        parameters. It has the signature
+        
+            ``objective_func(params) -> rss``
+
+        where ``params`` is a `lmfit.Parameters` object and ``rss`` is
+        the residual sum of squares (float). The parameter object should
+        contain all the parameters that are expected by the simulation
+        function.
+    
+    Examples
+    --------
+    Import required modules and functions:
+    >>> import numpy as np
+    >>> from lmfit import Parameters
+    >>> from lmfit import Minimizer
+    >>> from nasap.fitting.lmfit import make_objective_func_for_lmfit_minimizer
+    >>> from nasap.simulation import make_simulating_func_from_ode_rhs
+    
+    Define the ODE right-hand side function:
+    >>> def ode_rhs(t, y, k):
+    ...     return np.array([-k * y[0], k * y[0]])
+
+    Make a simulating function from the ODE right-hand side function:
+    >>> simulating_func = make_simulating_func_from_ode_rhs(ode_rhs)
+
+    Define the data:
+    >>> tdata = np.array([0, 0.1, 0.2])
+    >>> ydata = np.array([[1, 0], [0.9, 0.1], [0.82, 0.18]])
+
+    Define the initial conditions:
+    >>> y0 = np.array([1, 0])
+
+    Make the objective function:
+    >>> objective_func = make_objective_func_for_lmfit_minimizer(
+    ...     tdata, ydata, simulating_func, y0)
+
+    Define the parameters:
+    >>> params = Parameters()
+    >>> params.add('k', value=0.1)
+
+    Make the minimizer:
+    >>> minimizer = Minimizer(objective_func, params)
+
+    Run the minimizer:
+    >>> result = minimizer.minimize()
+    >>> result.params['k'].value
+    np.float64(1.006577440063097)  # may vary slightly
+    """
+    def objective_func(params: Parameters) -> float:
+        return calc_simulation_rss(
+            tdata, ydata, simulating_func, y0, **params.valuesdict())
+    
+    return objective_func

--- a/nasap/fitting/lmfit/tests/test_objective_func.py
+++ b/nasap/fitting/lmfit/tests/test_objective_func.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+from lmfit import Minimizer, Parameters
+
+from nasap.fitting.lmfit import make_objective_func_for_lmfit_minimizer
+from nasap.simulation import make_simulating_func_from_ode_rhs
+
+# TODO: Add more tests
+
+
+def test_use_for_lmfit_minimizer():
+    # A -> B
+    def ode_rhs(t, y, k):
+        return np.array([-k * y[0], k * y[0]])
+
+    simulating_func = make_simulating_func_from_ode_rhs(ode_rhs)
+
+    tdata = np.logspace(-3, 1, 12)
+    y0 = np.array([1, 0])
+    k = 1
+    ydata = simulating_func(tdata, y0, k)
+
+    objective_func = make_objective_func_for_lmfit_minimizer(
+        tdata, ydata, simulating_func, y0)
+
+    params = Parameters()
+    params.add('k', value=0.1)
+
+    minimizer = Minimizer(objective_func, params)
+
+    result = minimizer.minimize()
+
+    assert np.isclose(result.params['k'].value, k)
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new objective function for the `lmfit.Minimizer` class and includes corresponding tests. The changes primarily focus on adding the new function and ensuring it integrates well with existing code.

### New Objective Function for `lmfit.Minimizer`:

* [`nasap/fitting/lmfit/objective_func.py`](diffhunk://#diff-ea8864b5592357417c96ea36177ef13f7445b87fa6e74205b2c4f299fc3b3b0aR1-R100): Added the `make_objective_func_for_lmfit_minimizer` function, which creates an objective function for the `lmfit.Minimizer` class from a simulating function. This function calculates the residual sum of squares (RSS) between the data and the simulation for a given set of parameters.

### Integration and Testing:

* [`nasap/fitting/lmfit/__init__.py`](diffhunk://#diff-62712550de014a1e755967633e3a89c3f243bd69074d33a0012da79bc267934aR1): Included the new objective function in the module's namespace by importing everything from `objective_func.py`.
* [`nasap/fitting/lmfit/tests/test_objective_func.py`](diffhunk://#diff-d0e450067db7d97ef13369a711c9477dcd35e351e94d8d231f36b4b444380074R1-R37): Added a test case to validate the new objective function with the `lmfit.Minimizer` class. The test checks if the minimized parameter value is close to the expected value.