### PR TITLE
Add lmfit minimizer utility

### DIFF
--- a/nasap/fitting/lmfit/__init__.py
+++ b/nasap/fitting/lmfit/__init__.py
@@ -1,1 +1,2 @@
+from .minimizer import *
 from .objective_func import *

--- a/nasap/fitting/lmfit/minimizer.py
+++ b/nasap/fitting/lmfit/minimizer.py
@@ -1,0 +1,64 @@
+import inspect
+from collections.abc import Callable, Iterable
+from typing import Concatenate, ParamSpec, Protocol, TypeAlias, TypeVar
+
+import numpy.typing as npt
+from lmfit import Minimizer, Parameters
+
+from ..objective_func import make_objective_func_from_simulating_func
+from ..rss import calc_simulation_rss
+
+_P = ParamSpec('_P')
+
+
+def make_lmfit_minimizer(
+        tdata: npt.NDArray, ydata: npt.NDArray,
+        simulating_func: Callable[
+            Concatenate[npt.NDArray, npt.NDArray, _P], npt.NDArray],
+        y0: npt.NDArray,
+        params: Parameters,
+        ) -> Minimizer:
+    """Make a `lmfit.Minimizer` object from a simulating function.
+
+    Resulting minimizer can be used to minimize the residual sum of 
+    squares (RSS) between the data and the simulation.
+
+    Parameters
+    ----------
+    tdata : npt.NDArray, shape (n,)
+        Time points of the data.
+    ydata : npt.NDArray, shape (n, m)
+        Data to be compared with the simulation.
+        NaN values are ignored.
+    simulating_func : Callable
+        Function that simulates the system. 
+        
+            ``simulating_func(t, y0, *args, **kwargs) -> y``
+        
+        where ``t`` is the time points (1-D array, shape (n,)), 
+        ``y0`` is the initial values of the dependent variables
+        (1-D array, shape (m,)), ``args`` and ``kwargs`` are the
+        parameters of the simulation, and ``y`` is the dependent
+        variables at the time points (2-D array, shape (n, m)).
+    y0 : npt.NDArray, shape (m,)
+        Initial conditions.
+    params : lmfit.Parameters
+        Parameters for the minimization. The names of the parameters
+        should match the names of the arguments of the simulation
+        function.
+
+    Returns
+    -------
+    lmfit.Minimizer
+        The minimizer object that can be used to minimize the residual
+        sum of squares (RSS) between the data and the simulation.
+
+    Examples
+    --------
+    """
+    
+    def func_for_minimizer(params: Parameters) -> float:
+        return calc_simulation_rss(
+            tdata, ydata, simulating_func, y0, **params.valuesdict())
+
+    return Minimizer(func_for_minimizer, params)

--- a/nasap/fitting/lmfit/tests/test_minimizer.py
+++ b/nasap/fitting/lmfit/tests/test_minimizer.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pytest
+from lmfit import Parameters
+
+from nasap.fitting.lmfit import make_lmfit_minimizer
+from nasap.simulation import make_simulating_func_from_ode_rhs
+
+
+def test_use_for_simple_minimization():
+    # A -> B
+    def ode_rhs(t, y, k):
+        return np.array([-k * y[0], k * y[0]])
+
+    tdata = np.logspace(-3, 1, 12)
+    y0 = np.array([1, 0])
+    k = 1
+
+    simulating_func = make_simulating_func_from_ode_rhs(ode_rhs)
+    ydata = simulating_func(tdata, y0, k)
+
+    params = Parameters()
+    params.add('k', value=0.1)
+
+    minimizer = make_lmfit_minimizer(
+        tdata, ydata, simulating_func, y0, params)
+
+    result = minimizer.minimize()
+
+    assert np.isclose(result.params['k'].value, k)
+
+
+def test_use_for_differential_evolution():
+    # A -> B
+    def ode_rhs(t, y, k):
+        return np.array([-k * y[0], k * y[0]])
+
+    tdata = np.logspace(-3, 1, 12)
+    y0 = np.array([1, 0])
+    k = 1
+
+    simulating_func = make_simulating_func_from_ode_rhs(ode_rhs)
+    ydata = simulating_func(tdata, y0, k)
+
+    params = Parameters()
+    params.add('k', min=0, max=10)
+
+    minimizer = make_lmfit_minimizer(
+        tdata, ydata, simulating_func, y0, params)
+
+    result = minimizer.minimize(method='differential_evolution')
+
+    assert np.isclose(result.params['k'].value, k)
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new feature for creating and testing `lmfit.Minimizer` objects from simulating functions. The most important changes include the addition of a new function `make_lmfit_minimizer` and corresponding tests.

### New Features:

* [`nasap/fitting/lmfit/minimizer.py`](diffhunk://#diff-ffe773745f7c6dc56daf9af6d52789a0cf22936d1635b04c0670f117523830d5R1-R64): Added the `make_lmfit_minimizer` function, which creates a `lmfit.Minimizer` object for minimizing the residual sum of squares (RSS) between the data and the simulation. This function takes time data, observed data, a simulating function, initial conditions, and minimization parameters as inputs.

### Tests:

* [`nasap/fitting/lmfit/tests/test_minimizer.py`](diffhunk://#diff-4074dd369357296675ad52222d314691af5633eeb6d10de70759193119e87640R1-R56): Added tests for the `make_lmfit_minimizer` function to verify its functionality with simple minimization and differential evolution methods.

### Import Changes:

* [`nasap/fitting/lmfit/__init__.py`](diffhunk://#diff-62712550de014a1e755967633e3a89c3f243bd69074d33a0012da79bc267934aR1): Updated to import everything from the `minimizer` module.