### PR TITLE
Add iteration callback utility for `lmfit.Minimizer`

### DIFF
--- a/nasap/fitting/lmfit/__init__.py
+++ b/nasap/fitting/lmfit/__init__.py
@@ -1,2 +1,3 @@
+from .iter_cb import *
 from .minimizer import *
 from .objective_func import *

--- a/nasap/fitting/lmfit/iter_cb.py
+++ b/nasap/fitting/lmfit/iter_cb.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import numpy.typing as npt
+from lmfit import Parameters
+
+
+@dataclass
+class IterationRecord:
+    params: dict[str, float]
+    iter: int
+    resid: npt.NDArray
+
+
+class MinimizerIterCallback(Protocol):
+    def __call__(
+            self, params: Parameters, iter: int, resid: Any,
+            *args, **kwargs) -> None:
+        ...
+
+
+# TODO: Add examples
+def make_iter_cb_for_lmfit_minimizer() -> tuple[
+        MinimizerIterCallback, list[IterationRecord]]:
+    """Make an iteration callback function for the `lmfit.Minimizer` class.
+    
+    Returns
+    -------
+    iter_cb : MinimizerIterCallback
+        The iteration callback function that records the parameters and
+        residuals at each iteration.
+    records : list[IterationRecord]
+        The list of records that contain the parameters and residuals at
+        each iteration. The records are empty at the beginning of the
+        minimization, and they are filled by the iteration callback
+        function.
+
+        ``IterationRecord`` is a dataclass with the following attributes:
+
+        - ``params``: A dictionary that contains the parameter names and
+            values at the iteration.
+        - ``iter``: The iteration number. The first iteration is 0.
+        - ``resid``: The residuals at the iteration. It is a return value
+            of the ``userfcn`` function of the `lmfit.Minimizer` class.
+            It can be a 1-D array, float, or any other type that is
+            returned by the ``userfcn`` function.
+    """
+    records = []
+    def record_params(params, iter, resid, *args, **kwargs):
+        records.append(IterationRecord(
+            params=params.valuesdict(),
+            iter=iter + 1,  # Minimizer.nfev starts from -1
+            resid=resid.copy()
+            ))
+    return record_params, records

--- a/nasap/fitting/lmfit/tests/test_iter_cb.py
+++ b/nasap/fitting/lmfit/tests/test_iter_cb.py
@@ -1,0 +1,77 @@
+import numpy as np
+import numpy.typing as npt
+import pytest
+from lmfit import Minimizer, Parameters
+
+from nasap.fitting.lmfit import (IterationRecord,
+                                 make_iter_cb_for_lmfit_minimizer,
+                                 make_objective_func_for_lmfit_minimizer)
+from nasap.simulation import make_simulating_func_from_ode_rhs
+
+
+def test_use_for_lmfit_minimizer():
+    # A -> B
+    def ode_rhs(t, y, k):
+        return np.array([-k * y[0], k * y[0]])
+
+    simulating_func = make_simulating_func_from_ode_rhs(ode_rhs)
+
+    tdata = np.logspace(-3, 1, 12)
+    y0 = np.array([1, 0])
+    k = 1
+    ydata = simulating_func(tdata, y0, k)
+
+    objective_func = make_objective_func_for_lmfit_minimizer(
+        tdata, ydata, simulating_func, y0)
+
+    params = Parameters()
+    params.add('k', value=0.1)
+
+    iter_cb, records = make_iter_cb_for_lmfit_minimizer()
+    minimizer = Minimizer(objective_func, params, iter_cb=iter_cb)
+
+    result = minimizer.minimize()
+
+    assert np.isclose(result.params['k'].value, k)
+    assert len(records) > 0
+    assert isinstance(records[0], IterationRecord)
+    assert records[0].params.keys() == {'k'}
+    assert records[0].iter == 0
+    assert isinstance(records[0].resid, float)  # because the objective function returns a float
+
+
+def test_case_where_objective_func_returns_array():
+    # A -> B
+    def ode_rhs(t, y, k):
+        return np.array([-k * y[0], k * y[0]])
+
+    simulating_func = make_simulating_func_from_ode_rhs(ode_rhs)
+
+    tdata = np.logspace(-3, 1, 12)
+    y0 = np.array([1, 0])
+    k = 1
+    ydata = simulating_func(tdata, y0, k)
+
+    def objective_func(params: Parameters) -> npt.NDArray:
+        k = params['k']
+        ymodel = simulating_func(tdata, y0, k)
+        return ymodel - ydata  # This is an array
+
+    params = Parameters()
+    params.add('k', value=0.1)
+
+    iter_cb, records = make_iter_cb_for_lmfit_minimizer()
+    minimizer = Minimizer(objective_func, params, iter_cb=iter_cb)
+
+    result = minimizer.minimize()
+
+    assert np.isclose(result.params['k'].value, k)
+    assert len(records) > 0
+    assert isinstance(records[0], IterationRecord)
+    assert records[0].params.keys() == {'k'}
+    assert records[0].iter == 0
+    assert isinstance(records[0].resid, np.ndarray)  # because the objective function returns an array
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new iteration callback mechanism for the `lmfit.Minimizer` class and includes related tests. The key changes involve adding a new module for the iteration callback, updating the `__init__.py` to include this module, and creating test cases to ensure the functionality works as expected.

### New iteration callback mechanism:

* [`nasap/fitting/lmfit/__init__.py`](diffhunk://#diff-62712550de014a1e755967633e3a89c3f243bd69074d33a0012da79bc267934aR1): Added import statement for the new `iter_cb` module.
* [`nasap/fitting/lmfit/iter_cb.py`](diffhunk://#diff-aad0dc2ef14d8761b3291699927294306131fa0bd2923ea8ce90f1d96075a071R1-R55): Introduced `IterationRecord` dataclass and `MinimizerIterCallback` protocol. Implemented `make_iter_cb_for_lmfit_minimizer` function to create an iteration callback for the `lmfit.Minimizer` class.

### Tests for iteration callback:

* [`nasap/fitting/lmfit/tests/test_iter_cb.py`](diffhunk://#diff-3e67c7a65a965e04477bb3c72de3c9c0e163d60623c373dd2c9615845a43eceeR1-R77): Added test cases to validate the iteration callback functionality with different types of objective functions.