### PR TITLE
Add Protocol for simulating functions to enhance type safety

### DIFF
--- a/nasap/simulation/simulating_func.py
+++ b/nasap/simulation/simulating_func.py
@@ -3,16 +3,25 @@ Module for making simulating functions from ODE right-hand side functions.
 """
 
 from collections.abc import Callable
-from typing import Concatenate, ParamSpec
+from typing import Concatenate, Generic, ParamSpec, Protocol
 
 import numpy.typing as npt
 from scipy.integrate import solve_ivp
 
 _P = ParamSpec('_P')
 
+
+class SimulatingFunc(Generic[_P], Protocol):
+    def __call__(
+            self, t: npt.NDArray, y0: npt.NDArray,
+            *args: _P.args, **kwargs: _P.kwargs
+            ) -> npt.NDArray:
+        ...
+
+
 def make_simulating_func_from_ode_rhs(
         ode_rhs: Callable[Concatenate[float, npt.NDArray, _P], npt.NDArray]
-        ) -> Callable[Concatenate[npt.NDArray, npt.NDArray, _P], npt.NDArray]:
+        ) -> SimulatingFunc[_P]:
     """Make a simulating function from an ODE right-hand side function.
 
     Resulting simulating function can be called with time points, 


### PR DESCRIPTION
This pull request includes changes to the `nasap/simulation/simulating_func.py` file to enhance the type safety and flexibility of the simulation functions. The most important changes involve the introduction of a new protocol and the use of generics.

Enhancements to type safety and flexibility:

* [`nasap/simulation/simulating_func.py`](diffhunk://#diff-66eab44522c5e88fb61c43079e16aa0995508bae20c9192f084c39a94da0b973L6-R24): Added the `SimulatingFunc` protocol to define a callable type with specific argument and return types, improving type safety and flexibility.
* [`nasap/simulation/simulating_func.py`](diffhunk://#diff-66eab44522c5e88fb61c43079e16aa0995508bae20c9192f084c39a94da0b973L6-R24): Modified the return type of `make_simulating_func_from_ode_rhs` to use the new `SimulatingFunc` protocol, enhancing the function's type annotations.