### PR TITLE
Refactor imports in simulation module for cleaner access

### DIFF
--- a/nasap/simulation/__init__.py
+++ b/nasap/simulation/__init__.py
@@ -1,2 +1,2 @@
-from .gillespie import Gillespie
-from .simulating_func import make_simulating_func_from_ode_rhs
+from .gillespie import *
+from .simulating_func import *


### PR DESCRIPTION
This pull request includes changes to the import statements in the `nasap/simulation/__init__.py` file to improve code readability and maintainability.

* [`nasap/simulation/__init__.py`](diffhunk://#diff-53458123f84f68b4a0665a314b7f3b7480f183f0e0dfc04b261b13f2f99b079aL1-R2): Changed specific imports to wildcard imports for `Gillespie` and `make_simulating_func_from_ode_rhs` modules.