### PR TITLE
Add `SampleData` class for immutable sample data handling

### DIFF
--- a/nasap/fitting/sample_data/__init__.py
+++ b/nasap/fitting/sample_data/__init__.py
@@ -1,0 +1,1 @@
+from .sample_data import *

--- a/nasap/fitting/sample_data/sample_data.py
+++ b/nasap/fitting/sample_data/sample_data.py
@@ -1,0 +1,51 @@
+from types import MappingProxyType
+from typing import Generic, TypeVar
+
+import numpy as np
+import numpy.typing as npt
+from frozendict import frozendict
+
+_T = TypeVar('_T')
+
+
+class SampleData(Generic[_T]):
+    """Immutable class for sample data."""
+    def __init__(
+            self, tdata: npt.ArrayLike, ydata: npt.ArrayLike,
+            simulating_func: _T,
+            params: dict[str, float] | None = None) -> None:
+        self._tdata = np.array(tdata)
+        self._ydata = np.array(ydata)
+        self._simulating_func = simulating_func
+
+        if params is None:
+            params = {}
+        self._params = frozendict(params)
+    
+        self._tdata.flags.writeable = False
+        self._ydata.flags.writeable = False
+
+    @property
+    def tdata(self) -> npt.NDArray:
+        """Time points of the data. (Read-only)"""
+        return self._tdata
+    
+    @property
+    def ydata(self) -> npt.NDArray:
+        """Data to be compared with the simulation. (Read-only)"""
+        return self._ydata
+    
+    @property
+    def simulating_func(self) -> _T:
+        """Function that simulates the system."""
+        return self._simulating_func
+    
+    @property
+    def params(self) -> MappingProxyType[str, float]:
+        """Read-only dictionary of parameters."""
+        return MappingProxyType(self._params)
+
+    @property
+    def y0(self) -> npt.NDArray:
+        """Initial conditions. (Read-only)"""
+        return self.ydata[0]


### PR DESCRIPTION
This pull request introduces a new `SampleData` class to the `nasap/fitting/sample_data` module. The main changes include the addition of the `SampleData` class and the import of necessary modules.

New `SampleData` class:

* [`nasap/fitting/sample_data/sample_data.py`](diffhunk://#diff-4e1798a80b8ebc117c3b839ff8fc6c03c18874b20dd4409ec8d50cb0ebcacb81R1-R51): Added a new `SampleData` class, which is an immutable class for handling sample data. It includes properties for `tdata`, `ydata`, `simulating_func`, `params`, and `y0`.

Module import:

* [`nasap/fitting/sample_data/__init__.py`](diffhunk://#diff-a0ad5928f0f9a1b9b9470674edbf03016604b83cd91e41fdf8cc07174a440214R1): Imported all contents from `sample_data.py` to make the `SampleData` class accessible from the module.