### PR TITLE
Add A -> B reaction sample data

### DIFF
--- a/nasap/fitting/sample_data/tests/test_a_to_b.py
+++ b/nasap/fitting/sample_data/tests/test_a_to_b.py
@@ -2,9 +2,6 @@ from collections.abc import Callable
 
 import numpy as np
 import pytest
-from hypothesis import given
-from hypothesis import strategies as st
-from hypothesis.extra.numpy import array_shapes, arrays
 
 from nasap.fitting.sample_data import AToBParams, get_a_to_b_sample
 
@@ -19,25 +16,14 @@ def test_default_values():
     assert np.allclose(sim_result, sample.y)
 
 
-@given(
-    tdata=arrays(
-        dtype=float, shape=array_shapes(min_dims=1, max_dims=1),
-        elements=st.floats(min_value=0.0, max_value=10.0)),
-    y0=arrays(
-        dtype=float, shape=(2,),
-        elements=st.floats(min_value=0.0, max_value=10.0)),
-    k=st.floats(min_value=0.0, max_value=10.0))
-def test(tdata, y0, k):
-    tdata.sort()
-    sample = get_a_to_b_sample(
-        tdata=tdata, y0=y0, k=k)  # use custom values
-    assert isinstance(sample.t, np.ndarray)
-    assert sample.t.ndim == 1
-    n = sample.t.size
-    assert isinstance(sample.y, np.ndarray)
-    assert sample.y.shape == (n, 2)
-    assert isinstance(sample.simulating_func, Callable)
-    assert isinstance(sample.params, AToBParams)
+def test_custom_values():
+    t = np.logspace(-2, 1, 20)
+    y0 = np.array([0.5, 0.5])
+    k = 2.0
+    sample = get_a_to_b_sample(tdata=t, y0=y0, k=k)  # use custom values
+    np.testing.assert_allclose(sample.t, t)
+    np.testing.assert_allclose(sample.y[0], y0)
+    assert sample.params.k == k
 
     sim_result = sample.simulating_func(
         sample.t, sample.y[0], sample.params.k)

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,25 +18,6 @@ doc = ["Sphinx"]
 test = ["coverage", "pytest", "pytest-cov"]
 
 [[package]]
-name = "attrs"
-version = "24.2.0"
-description = "Classes Without Boilerplate"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "attrs-24.2.0-py3-none-any.whl", hash = "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"},
-    {file = "attrs-24.2.0.tar.gz", hash = "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346"},
-]
-
-[package.extras]
-benchmark = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-codspeed", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-cov = ["cloudpickle", "coverage[toml] (>=5.3)", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-dev = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
-tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -222,38 +203,6 @@ type1 = ["xattr"]
 ufo = ["fs (>=2.2.0,<3)"]
 unicode = ["unicodedata2 (>=15.1.0)"]
 woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
-
-[[package]]
-name = "hypothesis"
-version = "6.122.0"
-description = "A library for property-based testing"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "hypothesis-6.122.0-py3-none-any.whl", hash = "sha256:523451a187cb0e861074bc560c2d27382b7872c28b57c6e14e98bb2152fe3a0e"},
-    {file = "hypothesis-6.122.0.tar.gz", hash = "sha256:8f1675a62f70e2821b347f550e6d3b5478ec25470b6e0281c974b57ab53f5dc7"},
-]
-
-[package.dependencies]
-attrs = ">=22.2.0"
-sortedcontainers = ">=2.1.0,<3.0.0"
-
-[package.extras]
-all = ["black (>=19.10b0)", "click (>=7.0)", "crosshair-tool (>=0.0.78)", "django (>=4.2)", "dpcontracts (>=0.4)", "hypothesis-crosshair (>=0.0.18)", "lark (>=0.10.1)", "libcst (>=0.3.16)", "numpy (>=1.19.3)", "pandas (>=1.1)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "tzdata (>=2024.2)"]
-cli = ["black (>=19.10b0)", "click (>=7.0)", "rich (>=9.0.0)"]
-codemods = ["libcst (>=0.3.16)"]
-crosshair = ["crosshair-tool (>=0.0.78)", "hypothesis-crosshair (>=0.0.18)"]
-dateutil = ["python-dateutil (>=1.4)"]
-django = ["django (>=4.2)"]
-dpcontracts = ["dpcontracts (>=0.4)"]
-ghostwriter = ["black (>=19.10b0)"]
-lark = ["lark (>=0.10.1)"]
-numpy = ["numpy (>=1.19.3)"]
-pandas = ["pandas (>=1.1)"]
-pytest = ["pytest (>=4.6)"]
-pytz = ["pytz (>=2014.1)"]
-redis = ["redis (>=3.0.0)"]
-zoneinfo = ["tzdata (>=2024.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -894,17 +843,6 @@ files = [
 ]
 
 [[package]]
-name = "sortedcontainers"
-version = "2.4.0"
-description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
-optional = false
-python-versions = "*"
-files = [
-    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
-    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
-]
-
-[[package]]
 name = "types-pytz"
 version = "2024.2.0.20241003"
 description = "Typing stubs for pytz"
@@ -946,4 +884,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.13"
-content-hash = "cc2a3bd45b90601866e3ca72aceaafc274e9e49b06ba3323eb44d28ac1eb6eca"
+content-hash = "9724c9415a9cb7e34a6b263526b3ffaaac8e7b234fe6b282d79d37ffa18f58a9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ numdifftools = "^0.9.41"
 matplotlib = "^3.9.2"
 pandas = "^2.2.3"
 pandas-stubs = "^2.2.3.241009"
-hypothesis = "^6.122.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"


### PR DESCRIPTION
This pull request introduces a new sample data module for the A -> B reaction in the `nasap/fitting/sample_data` package. The changes include the addition of a new file for the A -> B reaction, updates to the module initialization file, and the creation of corresponding tests.

New sample data module:

* [`nasap/fitting/sample_data/a_to_b.py`](diffhunk://#diff-ca5b1e2e2faa929e6f845f299816db3ce86bbb25d83867fb2a7d7ed5dc72b1a9R1-R65): Added a new module that provides sample data for the A -> B reaction, including a class `AToBParams` and a function `get_a_to_b_sample` to generate the sample data.

Module initialization update:

* [`nasap/fitting/sample_data/__init__.py`](diffhunk://#diff-a0ad5928f0f9a1b9b9470674edbf03016604b83cd91e41fdf8cc07174a440214R1): Updated the initialization file to import all contents from the new `a_to_b` module.

Tests for the new module:

* [`nasap/fitting/sample_data/tests/test_a_to_b.py`](diffhunk://#diff-4144d0e95392d4bd37699822efbfab2db9668d91d0808af111fa608c0d06f1a7R1-R34): Added tests to verify the default and custom values of the sample data generated by the `get_a_to_b_sample` function.