### PR TITLE
Rename parameter `tdata` to `t` in `get_a_to_b_sample` function

### DIFF
--- a/nasap/fitting/sample_data/a_to_b.py
+++ b/nasap/fitting/sample_data/a_to_b.py
@@ -16,7 +16,7 @@ class AToBParams(NamedTuple):
 
 def get_a_to_b_sample(
         *,
-        tdata: npt.ArrayLike = np.logspace(-3, 1, 10),
+        t: npt.ArrayLike = np.logspace(-3, 1, 10),
         y0: npt.ArrayLike = np.array([1, 0]),
         k: float = 1.0
         ):  # Intentionally not providing return type,
@@ -55,11 +55,11 @@ def get_a_to_b_sample(
             Read-only dictionary of parameters.
         - y0 (npt.NDArray, shape (2,)): Initial conditions.
     """
-    tdata = np.array(tdata)
+    t = np.array(t)
     y0 = np.array(y0)
     
     def ode_rhs(t: float, y: npt.NDArray, k: float) -> npt.NDArray:
         return np.array([-k * y[0], k * y[0]])
     
     return SampleData(
-        ode_rhs, tdata, y0, AToBParams(k=k))
+        ode_rhs, t, y0, AToBParams(k=k))

--- a/nasap/fitting/sample_data/tests/test_a_to_b.py
+++ b/nasap/fitting/sample_data/tests/test_a_to_b.py
@@ -20,7 +20,7 @@ def test_custom_values():
     t = np.logspace(-2, 1, 20)
     y0 = np.array([0.5, 0.5])
     k = 2.0
-    sample = get_a_to_b_sample(tdata=t, y0=y0, k=k)  # use custom values
+    sample = get_a_to_b_sample(t=t, y0=y0, k=k)  # use custom values
     np.testing.assert_allclose(sample.t, t)
     np.testing.assert_allclose(sample.y[0], y0)
     assert sample.params.k == k


### PR DESCRIPTION
This pull request includes changes to the `nasap/fitting/sample_data/a_to_b.py` and `nasap/fitting/sample_data/tests/test_a_to_b.py` files to rename a parameter for clarity and consistency. The most important changes include renaming the `tdata` parameter to `t` in both the function definition and its usage.

Parameter renaming for clarity and consistency:

* [`nasap/fitting/sample_data/a_to_b.py`](diffhunk://#diff-ca5b1e2e2faa929e6f845f299816db3ce86bbb25d83867fb2a7d7ed5dc72b1a9L19-R19): Renamed the `tdata` parameter to `t` in the `get_a_to_b_sample` function definition and its usage. [[1]](diffhunk://#diff-ca5b1e2e2faa929e6f845f299816db3ce86bbb25d83867fb2a7d7ed5dc72b1a9L19-R19) [[2]](diffhunk://#diff-ca5b1e2e2faa929e6f845f299816db3ce86bbb25d83867fb2a7d7ed5dc72b1a9L58-R65)
* [`nasap/fitting/sample_data/tests/test_a_to_b.py`](diffhunk://#diff-4144d0e95392d4bd37699822efbfab2db9668d91d0808af111fa608c0d06f1a7L23-R23): Updated the test function `test_custom_values` to use the renamed `t` parameter instead of `tdata`.