### PR TITLE
Replace `np.isclose` with `np.testing.assert_allclose`

### DIFF
--- a/nasap/fitting/lmfit/tests/test_iter_cb.py
+++ b/nasap/fitting/lmfit/tests/test_iter_cb.py
@@ -25,7 +25,8 @@ def test_use_for_lmfit_minimizer():
 
     result = minimizer.minimize()
 
-    assert np.isclose(result.params['k'].value, sample.params.k)
+    np.testing.assert_allclose(
+        result.params['k'].value, sample.params.k, rtol=1e-4)
     assert len(records) > 0
     assert isinstance(records[0], IterationRecord)
     assert records[0].params.keys() == {'k'}
@@ -52,7 +53,7 @@ def test_case_where_objective_func_returns_array():
 
     result = minimizer.minimize()
 
-    assert np.isclose(result.params['k'].value, sample.params.k)
+    np.testing.assert_allclose(result.params['k'].value, sample.params.k)
     assert len(records) > 0
     assert isinstance(records[0], IterationRecord)
     assert records[0].params.keys() == {'k'}

--- a/nasap/fitting/lmfit/tests/test_minimizer.py
+++ b/nasap/fitting/lmfit/tests/test_minimizer.py
@@ -18,7 +18,8 @@ def test_use_for_simple_minimization():
 
     result = minimizer.minimize()
 
-    assert np.isclose(result.params['k'].value, sample.params.k)
+    np.testing.assert_allclose(
+        result.params['k'].value, sample.params.k, rtol=1e-4)
 
 
 def test_use_for_differential_evolution():
@@ -33,7 +34,7 @@ def test_use_for_differential_evolution():
 
     result = minimizer.minimize(method='differential_evolution')
 
-    assert np.isclose(result.params['k'].value, sample.params.k)
+    np.testing.assert_allclose(result.params['k'].value, sample.params.k)
 
 
 if __name__ == '__main__':

--- a/nasap/fitting/lmfit/tests/test_objective_func.py
+++ b/nasap/fitting/lmfit/tests/test_objective_func.py
@@ -22,7 +22,8 @@ def test_use_for_lmfit_minimizer():
 
     result = minimizer.minimize()
 
-    assert np.isclose(result.params['k'].value, sample.params.k)
+    np.testing.assert_allclose(
+        result.params['k'].value, sample.params.k, rtol=1e-4)
 
 
 if __name__ == '__main__':

--- a/nasap/fitting/sample_data/tests/test_a_to_b.py
+++ b/nasap/fitting/sample_data/tests/test_a_to_b.py
@@ -8,12 +8,12 @@ from nasap.fitting.sample_data import AToBParams, get_a_to_b_sample
 
 def test_default_values():
     sample = get_a_to_b_sample()  # use default values
-    assert np.allclose(sample.t, np.logspace(-3, 1, 10))
+    np.testing.assert_allclose(sample.t, np.logspace(-3, 1, 10))
     assert isinstance(sample.simulating_func, Callable)
     assert sample.params == AToBParams(k=1.0)
     sim_result = sample.simulating_func(
         sample.t, np.array([1, 0]), sample.params.k)
-    assert np.allclose(sim_result, sample.y)
+    np.testing.assert_allclose(sim_result, sample.y)
 
 
 def test_custom_values():
@@ -27,7 +27,7 @@ def test_custom_values():
 
     sim_result = sample.simulating_func(
         sample.t, sample.y[0], sample.params.k)
-    assert np.allclose(sim_result, sample.y)
+    np.testing.assert_allclose(sim_result, sample.y)
 
 
 if __name__ == '__main__':

--- a/nasap/fitting/sample_data/tests/test_sample_data.py
+++ b/nasap/fitting/sample_data/tests/test_sample_data.py
@@ -19,8 +19,8 @@ def test_init() -> None:
     sample = SampleData(ode_rhs, t, y0, params)
 
     assert sample.ode_rhs is ode_rhs
-    assert np.array_equal(sample.t, t)
-    assert np.array_equal(sample.y0, y0)
+    np.testing.assert_array_equal(sample.t, t)
+    np.testing.assert_array_equal(sample.y0, y0)
     assert sample.params == params
 
 

--- a/nasap/fitting/tests/test_objective_func.py
+++ b/nasap/fitting/tests/test_objective_func.py
@@ -16,8 +16,8 @@ def test_use_for_differential_evolution():
 
     result = differential_evolution(objective_func, [(0, 10)])
 
-    assert np.isclose(result.fun, 0.0)
-    assert np.isclose(result.x, sample.params.k)
+    np.testing.assert_allclose(result.fun, 0.0)
+    np.testing.assert_allclose(result.x, sample.params.k)
 
 
 if __name__ == '__main__':

--- a/nasap/fitting/tests/test_rss.py
+++ b/nasap/fitting/tests/test_rss.py
@@ -14,9 +14,9 @@ def test_zero_rss():
 
     rss = calc_simulation_rss(
         sample.t, sample.y, sample.simulating_func, sample.y0, 
-        k=sample.params.k)
+        k=sample.params.k)  # Use the correct value
     
-    assert rss == 0.0
+    np.testing.assert_allclose(rss, 0.0)
 
 
 def test_non_zero_rss():
@@ -26,14 +26,15 @@ def test_non_zero_rss():
 
     rss = calc_simulation_rss(
         sample.t, sample.y, sample.simulating_func, sample.y0,
-        k=k_with_error)
+        k=k_with_error)  # Use the incorrect value
 
     assert rss > 0.0
 
     y_with_error = sample.simulating_func(
         sample.t, sample.y0, k=k_with_error)
 
-    assert rss == np.sum((sample.y - y_with_error)**2)
+    np.testing.assert_allclose(
+        np.sum((sample.y - y_with_error)**2), rss)
 
 
 def test_ydata_with_row_of_nan():
@@ -53,7 +54,7 @@ def test_ydata_with_row_of_nan():
 
     rss = calc_simulation_rss(tdata, ydata, mock_sim_func, y0, k=1)
 
-    assert rss == 0.1**2 * 5
+    np.testing.assert_allclose(rss, 0.1**2 * 5)
 
 
 def test_use_for_basin_hopping():
@@ -72,7 +73,7 @@ def test_use_for_basin_hopping():
 
     result = basinhopping(f, 0.0)
 
-    assert np.isclose(result.fun, 0.0)
+    np.testing.assert_allclose(result.fun, 0.0, atol=1e-4)
 
 
 def test_use_for_differential_evolution():
@@ -91,7 +92,7 @@ def test_use_for_differential_evolution():
 
     result = differential_evolution(f, bounds=[(0, 10)])
 
-    assert np.isclose(result.fun, 0.0)
+    np.testing.assert_allclose(result.fun, 0.0, atol=1e-4)
 
 
 if __name__ == '__main__':

--- a/nasap/simulation/tests/test_gillespie.py
+++ b/nasap/simulation/tests/test_gillespie.py
@@ -15,10 +15,10 @@ def test_init():
         init_particle_counts, rates_fun, particle_changes, 
         t_max=10.0)
 
-    assert np.array_equal(
+    np.testing.assert_allclose(
         gillespie.particle_counts_seq[0], init_particle_counts)
     assert gillespie.rates_fun == rates_fun
-    assert np.array_equal(
+    np.testing.assert_allclose(
         gillespie.particle_changes, particle_changes)
     assert gillespie.t_max == 10.0
     assert gillespie.max_iter == 1_000_000
@@ -41,7 +41,7 @@ def test_solve():
         Status.REACHED_T_MAX, Status.REACHED_MAX_ITER, 
         Status.TOTAL_RATE_ZERO}
     assert result.t_seq[0] == 0.0
-    assert np.array_equal(
+    np.testing.assert_allclose(
         result.particle_counts_seq[0], init_particle_counts)
 
 
@@ -138,7 +138,7 @@ def test_gillespie_init_based_on_concentrations():
         init_concentrations, conc_rates_fun, particle_changes, volume, 
         t_max=10.0)
 
-    assert np.allclose(
+    np.testing.assert_allclose(
         gillespie.particle_counts_seq[0], 
         init_concentrations * Avogadro * volume)
     assert gillespie.volume == volume
@@ -173,11 +173,11 @@ def test_with_example_reaction():
 
     atol = 500  # 5%
 
-    assert np.allclose(
+    np.testing.assert_allclose(
         result.particle_counts_seq[:, 0], expected_A, atol=atol)
-    assert np.allclose(
+    np.testing.assert_allclose(
         result.particle_counts_seq[:, 1], expected_B, atol=atol)
-    assert np.allclose(
+    np.testing.assert_allclose(
         result.particle_counts_seq[:, 2], expected_C, atol=atol)
     
 


### PR DESCRIPTION
This pull request focuses on improving the numerical accuracy and consistency of various test cases by replacing the `np.isclose` and `np.allclose` assertions with `np.testing.assert_allclose` and `np.testing.assert_array_equal` where appropriate. This change enhances the clarity and robustness of the tests across multiple files.

### Improvements to test assertions:

* [`nasap/fitting/lmfit/tests/test_iter_cb.py`](diffhunk://#diff-3e67c7a65a965e04477bb3c72de3c9c0e163d60623c373dd2c9615845a43eceeL28-R29): Replaced `np.isclose` with `np.testing.assert_allclose` in `test_use_for_lmfit_minimizer` and `objective_func` functions to improve numerical accuracy. [[1]](diffhunk://#diff-3e67c7a65a965e04477bb3c72de3c9c0e163d60623c373dd2c9615845a43eceeL28-R29) [[2]](diffhunk://#diff-3e67c7a65a965e04477bb3c72de3c9c0e163d60623c373dd2c9615845a43eceeL55-R56)
* [`nasap/fitting/lmfit/tests/test_minimizer.py`](diffhunk://#diff-4074dd369357296675ad52222d314691af5633eeb6d10de70759193119e87640L21-R22): Updated `test_use_for_simple_minimization` and `test_use_for_differential_evolution` to use `np.testing.assert_allclose` instead of `np.isclose`. [[1]](diffhunk://#diff-4074dd369357296675ad52222d314691af5633eeb6d10de70759193119e87640L21-R22) [[2]](diffhunk://#diff-4074dd369357296675ad52222d314691af5633eeb6d10de70759193119e87640L36-R37)
* [`nasap/fitting/sample_data/tests/test_a_to_b.py`](diffhunk://#diff-4144d0e95392d4bd37699822efbfab2db9668d91d0808af111fa608c0d06f1a7L11-R16): Replaced `np.allclose` with `np.testing.assert_allclose` in `test_default_values` and `test_custom_values` functions. [[1]](diffhunk://#diff-4144d0e95392d4bd37699822efbfab2db9668d91d0808af111fa608c0d06f1a7L11-R16) [[2]](diffhunk://#diff-4144d0e95392d4bd37699822efbfab2db9668d91d0808af111fa608c0d06f1a7L30-R30)
* [`nasap/fitting/sample_data/tests/test_sample_data.py`](diffhunk://#diff-0d1ef13b9d411c8a2d56e3443fc46017f622a4516aecbf4c176816727ffaf62cL22-R23): Changed `np.array_equal` to `np.testing.assert_array_equal` for improved array comparison in `Params` class.
* [`nasap/fitting/tests/test_objective_func.py`](diffhunk://#diff-9c863bbafd0801cd4f1ae0088ff47883f178c12f0e5bc5ba864c4f4dbeb474dbL19-R20): Updated `test_use_for_differential_evolution` to use `np.testing.assert_allclose` instead of `np.isclose`.
* [`nasap/fitting/tests/test_rss.py`](diffhunk://#diff-9c671457bcd653f64449d65174e449588bf6bb986f1e4a2a364a584a000733b3L17-R19): Replaced `np.isclose` and `np.allclose` with `np.testing.assert_allclose` in multiple functions to ensure better numerical precision. [[1]](diffhunk://#diff-9c671457bcd653f64449d65174e449588bf6bb986f1e4a2a364a584a000733b3L17-R19) [[2]](diffhunk://#diff-9c671457bcd653f64449d65174e449588bf6bb986f1e4a2a364a584a000733b3L29-R37) [[3]](diffhunk://#diff-9c671457bcd653f64449d65174e449588bf6bb986f1e4a2a364a584a000733b3L56-R57) [[4]](diffhunk://#diff-9c671457bcd653f64449d65174e449588bf6bb986f1e4a2a364a584a000733b3L75-R76) [[5]](diffhunk://#diff-9c671457bcd653f64449d65174e449588bf6bb986f1e4a2a364a584a000733b3L94-R95)
* [`nasap/simulation/tests/test_gillespie.py`](diffhunk://#diff-e0fc689b0543b0a2cd61c269a92e595be7b0575641f8d24c9f594948c7e2da04L18-R21): Improved numerical comparisons by using `np.testing.assert_allclose` instead of `np.array_equal` and `np.allclose` in various test functions. [[1]](diffhunk://#diff-e0fc689b0543b0a2cd61c269a92e595be7b0575641f8d24c9f594948c7e2da04L18-R21) [[2]](diffhunk://#diff-e0fc689b0543b0a2cd61c269a92e595be7b0575641f8d24c9f594948c7e2da04L44-R44) [[3]](diffhunk://#diff-e0fc689b0543b0a2cd61c269a92e595be7b0575641f8d24c9f594948c7e2da04L141-R141) [[4]](diffhunk://#diff-e0fc689b0543b0a2cd61c269a92e595be7b0575641f8d24c9f594948c7e2da04L176-R180)