### PR TITLE
Provide proper tolerance parameters in `np.testing.assert_allclose`

### DIFF
--- a/nasap/fitting/lmfit/tests/test_iter_cb.py
+++ b/nasap/fitting/lmfit/tests/test_iter_cb.py
@@ -18,7 +18,7 @@ def test_use_for_lmfit_minimizer():
     # `objective_func` returns a float
 
     params = Parameters()
-    params.add('k', value=0.0)  # Initial guess
+    params.add('log_k', value=1.0)  # Initial guess
 
     iter_cb, records = make_iter_cb_for_lmfit_minimizer()
     minimizer = Minimizer(objective_func, params, iter_cb=iter_cb)
@@ -26,10 +26,10 @@ def test_use_for_lmfit_minimizer():
     result = minimizer.minimize()
 
     np.testing.assert_allclose(
-        result.params['k'].value, sample.params.k, rtol=1e-4)
+        result.params['log_k'].value, sample.params.log_k, atol=1e-3)
     assert len(records) > 0
     assert isinstance(records[0], IterationRecord)
-    assert records[0].params.keys() == {'k'}
+    assert records[0].params.keys() == {'log_k'}
     assert records[0].iter == 0
     # The type of `resid` should be the same as the return type of 
     # `objective_func`
@@ -41,22 +41,23 @@ def test_case_where_objective_func_returns_array():
     sample = get_a_to_b_sample()
 
     def objective_func(params: Parameters) -> npt.NDArray:
-        k = params['k']
-        ymodel = sample.simulating_func(sample.t, sample.y0, k)
+        log_k = params['log_k']
+        ymodel = sample.simulating_func(sample.t, sample.y0, log_k)
         return ymodel - sample.y  # This is an array
 
     params = Parameters()
-    params.add('k', value=0.0)  # Initial guess
+    params.add('log_k', value=1.0)  # Initial guess
 
     iter_cb, records = make_iter_cb_for_lmfit_minimizer()
     minimizer = Minimizer(objective_func, params, iter_cb=iter_cb)
 
     result = minimizer.minimize()
 
-    np.testing.assert_allclose(result.params['k'].value, sample.params.k)
+    np.testing.assert_allclose(
+        result.params['log_k'].value, sample.params.log_k, atol=1e-3)
     assert len(records) > 0
     assert isinstance(records[0], IterationRecord)
-    assert records[0].params.keys() == {'k'}
+    assert records[0].params.keys() == {'log_k'}
     assert records[0].iter == 0
     assert isinstance(records[0].resid, np.ndarray)  # array
 

--- a/nasap/fitting/lmfit/tests/test_minimizer.py
+++ b/nasap/fitting/lmfit/tests/test_minimizer.py
@@ -11,7 +11,7 @@ def test_use_for_simple_minimization():
     sample = get_a_to_b_sample()
 
     params = Parameters()
-    params.add('k', value=0.0)  # Initial guess
+    params.add('log_k', value=0.0)  # Initial guess
 
     minimizer = make_lmfit_minimizer(
         sample.t, sample.y, sample.simulating_func, sample.y0, params)
@@ -19,7 +19,7 @@ def test_use_for_simple_minimization():
     result = minimizer.minimize()
 
     np.testing.assert_allclose(
-        result.params['k'].value, sample.params.k, rtol=1e-4)
+        result.params['log_k'].value, sample.params.log_k, atol=1e-3)
 
 
 def test_use_for_differential_evolution():
@@ -27,14 +27,15 @@ def test_use_for_differential_evolution():
     sample = get_a_to_b_sample()
 
     params = Parameters()
-    params.add('k', min=0, max=10)
+    params.add('log_k', min=-3, max=3)
 
     minimizer = make_lmfit_minimizer(
         sample.t, sample.y, sample.simulating_func, sample.y0, params)
 
     result = minimizer.minimize(method='differential_evolution')
 
-    np.testing.assert_allclose(result.params['k'].value, sample.params.k)
+    np.testing.assert_allclose(
+        result.params['log_k'].value, sample.params.log_k, atol=1e-3)
 
 
 if __name__ == '__main__':

--- a/nasap/fitting/lmfit/tests/test_objective_func.py
+++ b/nasap/fitting/lmfit/tests/test_objective_func.py
@@ -16,14 +16,14 @@ def test_use_for_lmfit_minimizer():
         sample.t, sample.y, sample.simulating_func, sample.y0)
 
     params = Parameters()
-    params.add('k', value=0.0)  # Initial guess
+    params.add('log_k', value=0.0)  # Initial guess
 
     minimizer = Minimizer(objective_func, params)
 
     result = minimizer.minimize()
 
     np.testing.assert_allclose(
-        result.params['k'].value, sample.params.k, rtol=1e-4)
+        result.params['log_k'].value, sample.params.log_k, atol=1e-3)
 
 
 if __name__ == '__main__':

--- a/nasap/fitting/sample_data/a_to_b.py
+++ b/nasap/fitting/sample_data/a_to_b.py
@@ -11,14 +11,14 @@ from .sample_data import SampleData
 
 
 class AToBParams(NamedTuple):
-    k: float
+    log_k: float
 
 
 def get_a_to_b_sample(
         *,
         t: npt.ArrayLike = np.logspace(-3, 1, 10),
         y0: npt.ArrayLike = np.array([1, 0]),
-        k: float = 1.0
+        log_k: float = 0.0
         ):  # Intentionally not providing return type,
     # because when return type, `SampleData`, is provided,
     # somehow mypy does not infer the generic type of `SampleData`.
@@ -36,7 +36,7 @@ def get_a_to_b_sample(
     - ``[B] = 0.0``
     
     Kinetic constants:
-    - ``k = 1.0``
+    - ``k = 1.0``  i.e. ``log_k = 0.0``
 
     Time points: ``np.logspace(-3, 1, 10)``
     
@@ -58,8 +58,8 @@ def get_a_to_b_sample(
     t = np.array(t)
     y0 = np.array(y0)
     
-    def ode_rhs(t: float, y: npt.NDArray, k: float) -> npt.NDArray:
+    def ode_rhs(t: float, y: npt.NDArray, log_k: float) -> npt.NDArray:
+        k = 10**log_k
         return np.array([-k * y[0], k * y[0]])
     
-    return SampleData(
-        ode_rhs, t, y0, AToBParams(k=k))
+    return SampleData(ode_rhs, t, y0, AToBParams(log_k))

--- a/nasap/fitting/sample_data/sample_data.py
+++ b/nasap/fitting/sample_data/sample_data.py
@@ -56,7 +56,26 @@ class SampleData(Generic[_P, _S]):
     
     @property
     def simulating_func(self) -> SimulatingFunc[_P]:
-        """Function that simulates the system."""
+        """Function that simulates the system.
+        
+        It has the signature
+            
+                ``simulating_func(t, y0, *args, **kwargs) -> y``
+            
+            where ``t`` is the time points (1-D array, shape (n,)),
+            ``y0`` is the initial values of the dependent variables
+            (1-D array, shape (m,)), ``args`` and ``kwargs`` are the
+            parameters of the ODE right-hand side function, and ``y``
+            is the dependent variables at the time points (2-D array,
+            shape (n, m)).
+
+        Notes
+        -----
+        THe simulating function uses the `scipy.integrate.solve_ivp`
+        to simulate the system. For the tolerance, it uses the
+        default values of `scipy.integrate.solve_ivp`, which are
+        ``rtol=1e-3`` and ``atol=1e-6``.
+        """
         return self._simulating_func
     
     @property

--- a/nasap/fitting/sample_data/tests/test_a_to_b.py
+++ b/nasap/fitting/sample_data/tests/test_a_to_b.py
@@ -10,24 +10,26 @@ def test_default_values():
     sample = get_a_to_b_sample()  # use default values
     np.testing.assert_allclose(sample.t, np.logspace(-3, 1, 10))
     assert isinstance(sample.simulating_func, Callable)
-    assert sample.params == AToBParams(k=1.0)
+    assert sample.params == AToBParams(log_k=0.0)
     sim_result = sample.simulating_func(
-        sample.t, np.array([1, 0]), sample.params.k)
-    np.testing.assert_allclose(sim_result, sample.y)
+        sample.t, np.array([1, 0]), sample.params.log_k)
+    
+    np.testing.assert_allclose(sim_result, sample.y, rtol=1e-3, atol=1e-6)
 
 
 def test_custom_values():
     t = np.logspace(-2, 1, 20)
     y0 = np.array([0.5, 0.5])
-    k = 2.0
-    sample = get_a_to_b_sample(t=t, y0=y0, k=k)  # use custom values
+    log_k = 1.0
+    sample = get_a_to_b_sample(t=t, y0=y0, log_k=log_k)  # use custom values
     np.testing.assert_allclose(sample.t, t)
     np.testing.assert_allclose(sample.y[0], y0)
-    assert sample.params.k == k
+    assert sample.params.log_k == log_k
 
     sim_result = sample.simulating_func(
-        sample.t, sample.y[0], sample.params.k)
-    np.testing.assert_allclose(sim_result, sample.y)
+        sample.t, sample.y[0], sample.params.log_k)
+    
+    np.testing.assert_allclose(sim_result, sample.y, rtol=1e-3, atol=1e-6)
 
 
 if __name__ == '__main__':

--- a/nasap/fitting/sample_data/tests/test_sample_data.py
+++ b/nasap/fitting/sample_data/tests/test_sample_data.py
@@ -95,7 +95,7 @@ def test_simulating_func() -> None:
     
     y = sample.simulating_func(t, y0, params.k)
     
-    np.testing.assert_allclose(y, expected)
+    np.testing.assert_allclose(y, expected, rtol=1e-3, atol=1e-6)
 
 
 def test_y() -> None:
@@ -114,8 +114,7 @@ def test_y() -> None:
     expected = sample.simulating_func(t, y0, params.k)
 
     y = sample.y
-
-    np.testing.assert_allclose(y, expected)
+    np.testing.assert_allclose(y, expected, rtol=1e-3, atol=1e-6)
 
 
 if __name__ == '__main__':

--- a/nasap/fitting/tests/test_objective_func.py
+++ b/nasap/fitting/tests/test_objective_func.py
@@ -14,10 +14,10 @@ def test_use_for_differential_evolution():
     objective_func = make_objective_func_from_simulating_func(
         sample.t, sample.y, sample.simulating_func, sample.y0)
 
-    result = differential_evolution(objective_func, [(0, 10)])
+    result = differential_evolution(objective_func, [(-3, 3)])
 
-    np.testing.assert_allclose(result.fun, 0.0)
-    np.testing.assert_allclose(result.x, sample.params.k)
+    assert result.success
+    np.testing.assert_allclose(result.x, sample.params.log_k, atol=1e-3)
 
 
 if __name__ == '__main__':

--- a/nasap/simulation/simulating_func.py
+++ b/nasap/simulation/simulating_func.py
@@ -58,6 +58,16 @@ def make_simulating_func_from_ode_rhs(
         parameters of the ODE right-hand side function, and ``y``
         is the dependent variables at the time points (2-D array,
         shape (n, m)).
+    
+    Notes
+    -----
+    The simulating function uses `scipy.integrate.solve_ivp` to
+    solve the ODEs with the default method `RK45`. The ``solve_ivp``
+    function is called without specifying the `t_eval` argument for
+    efficiency, and the result is interpolated using the dense
+    output.
+    Default values of `rtol` and `atol` are used for the `solve_ivp`
+    function. The default values are `1e-3` and `1e-6`, respectively.
     """
     def simulating_func(
             t: npt.NDArray, y0: npt.NDArray,

--- a/nasap/simulation/tests/test_simulating_func.py
+++ b/nasap/simulation/tests/test_simulating_func.py
@@ -28,7 +28,7 @@ def test_one_reaction():
     y = simulating_func(t, y0, k)
 
     assert y.shape == (len(t), len(y0))
-    np.testing.assert_allclose(y, expected)
+    np.testing.assert_allclose(y, expected, rtol=1e-3, atol=1e-6)
 
 
 def test_two_reactions():
@@ -49,7 +49,7 @@ def test_two_reactions():
     y = simulating_func(t, y0, k1, k2)
 
     assert y.shape == (len(t), len(y0))
-    np.testing.assert_allclose(y, expected)
+    np.testing.assert_allclose(y, expected, rtol=1e-3, atol=1e-6)
 
 
 def test_reversible_reaction():
@@ -70,7 +70,7 @@ def test_reversible_reaction():
     y = simulating_func(t, y0, k1, k2)
 
     assert y.shape == (len(t), len(y0))
-    np.testing.assert_allclose(y, expected)
+    np.testing.assert_allclose(y, expected, rtol=1e-3, atol=1e-6)
 
 
 @st.composite
@@ -108,7 +108,7 @@ def test_simulating_func(t_y0_log_k_mat: tuple) -> None:
 
     y = simulating_func(t, y0, k_mat)
 
-    np.testing.assert_allclose(y, expected)
+    np.testing.assert_allclose(y, expected, rtol=1e-3, atol=1e-6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary
This PR focuses on setting appropriate `rtol` and `atol` values in the `np.testing.assert_allclose` function. The following changes were made:

### Changes
1. **Code Changes:**
    - Updated `nasap/fitting/lmfit/tests/test_iter_cb.py`: 
        - Changed `k` parameter to `log_k`.
        - Set `atol=1e-3` for `np.testing.assert_allclose`.
    - Updated `nasap/fitting/lmfit/tests/test_minimizer.py`:
        - Changed `k` parameter to `log_k`.
        - Set `atol=1e-3` for `np.testing.assert_allclose`.
    - Updated `nasap/fitting/lmfit/tests/test_objective_func.py`:
        - Changed `k` parameter to `log_k`.
        - Set `atol=1e-3` for `np.testing.assert_allclose`.
    - Other updates

2. **Documentation:**
    - Included details about `rtol` and `atol` values in the documentation to ensure clarity and proper usage.

### Tests
- All relevant test cases were updated with proper `rtol` and `atol` values to ensure accurate numerical comparisons.
- Verified that all tests pass with the new tolerance settings.

---

This PR aims to improve the reliability and precision of numerical comparisons in the test suite by appropriately setting tolerance parameters.