### PR TITLE
Enable checking of untyped definitions in mypy configuration

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 plugins = numpy.typing.mypy_plugin
+check_untyped_defs = True
 
 [mypy-scipy.*]
 ignore_missing_imports = True


### PR DESCRIPTION
This pull request includes a small change to the `mypy.ini` file. The change enables checking of untyped definitions.

* [`mypy.ini`](diffhunk://#diff-6f2d4ba9ca9a357d31014946667b7bed1bfdbc6d2530afc77778fa0a36bee457R3): Added `check_untyped_defs = True` to ensure that untyped definitions are checked during type checking.