### PR TITLE
Refactor test to use `callable` instead of `isinstance`

### DIFF
--- a/nasap/fitting/sample_data/tests/test_a_to_b.py
+++ b/nasap/fitting/sample_data/tests/test_a_to_b.py
@@ -9,7 +9,7 @@ from nasap.fitting.sample_data import AToBParams, get_a_to_b_sample
 def test_default_values():
     sample = get_a_to_b_sample()  # use default values
     np.testing.assert_allclose(sample.t, np.logspace(-3, 1, 10))
-    assert isinstance(sample.simulating_func, Callable)
+    assert callable(sample.simulating_func)
     assert sample.params == AToBParams(log_k=0.0)
     sim_result = sample.simulating_func(
         sample.t, np.array([1, 0]), sample.params.log_k)


### PR DESCRIPTION
This pull request includes a small change to the `nasap/fitting/sample_data/tests/test_a_to_b.py` file to improve the readability and correctness of the test assertions.

* [`nasap/fitting/sample_data/tests/test_a_to_b.py`](diffhunk://#diff-4144d0e95392d4bd37699822efbfab2db9668d91d0808af111fa608c0d06f1a7L12-R12): Replaced `isinstance` check with `callable` to verify that `sample.simulating_func` is a callable function.