### PR TITLE
Refactor `Gillespie` tests to add typing

### DIFF
--- a/nasap/simulation/tests/test_gillespie.py
+++ b/nasap/simulation/tests/test_gillespie.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy.typing as npt
 import pytest
 from scipy.constants import Avogadro
 
@@ -9,7 +10,8 @@ from nasap.simulation.gillespie import GillespieResult, Status
 def test_init():
     # A <-> B
     init_particle_counts = np.array([100, 200])
-    rates_fun = lambda x: [0.1, 0.2]
+    def rates_fun(x: npt.NDArray[np.int_]) -> npt.NDArray:
+        return np.array([0.1, 0.2])
     particle_changes = [np.array([-1, 1]), np.array([1, -1])]
     gillespie = Gillespie(
         init_particle_counts, rates_fun, particle_changes, 
@@ -28,7 +30,8 @@ def test_init():
 def test_solve():
     # A <-> B
     init_particle_counts = np.array([100, 200])
-    rates_fun = lambda x: [0.1, 0.2]
+    def rates_fun(x: npt.NDArray[np.int_]) -> npt.NDArray:
+        return np.array([0.1, 0.2])
     particle_changes = [np.array([-1, 1]), np.array([1, -1])]
     gillespie = Gillespie(
         init_particle_counts, rates_fun, particle_changes, 
@@ -48,7 +51,8 @@ def test_solve():
 def test_step_count():
     # A <-> B
     init_particle_counts = np.array([100, 200])
-    rates_fun = lambda x: [0.1, 0.2]
+    def rates_fun(x: npt.NDArray[np.int_]) -> npt.NDArray:
+        return np.array([0.1, 0.2])
     particle_changes = [np.array([-1, 1]), np.array([1, -1])]
     gillespie = Gillespie(
         init_particle_counts, rates_fun, particle_changes, 
@@ -62,7 +66,8 @@ def test_step_count():
 def test_status_of_max_iter_reached():
     # A <-> B
     init_particle_counts = np.array([100, 200])
-    rates_fun = lambda x: [0.1, 0.2]
+    def rates_fun(x: npt.NDArray[np.int_]) -> npt.NDArray:
+        return np.array([0.1, 0.2])
     particle_changes = [np.array([-1, 1]), np.array([1, -1])]
     gillespie = Gillespie(
         init_particle_counts, rates_fun, particle_changes, 
@@ -79,8 +84,8 @@ def test_status_of_total_rate_zero():
     # Few particles, so the total rate becomes zero
     # before the max iteration is reached.
     init_particle_counts = np.array([10, 0])
-
-    rates_fun = lambda x: [0.1 * x[0]]
+    def rates_fun(x: npt.NDArray[np.int_]) -> npt.NDArray:
+        return np.array([0.1 * x[0]])
     particle_changes = [np.array([-1, 1])]
     gillespie = Gillespie(
         init_particle_counts, rates_fun, particle_changes, 
@@ -97,7 +102,8 @@ def test_status_of_total_rate_zero():
 def test_status_of_t_max_reached():
     # A <-> B
     init_particle_counts = np.array([100, 200])
-    rates_fun = lambda x: [0.1 * x[0], 0.2 * x[1]]
+    def rates_fun(x: npt.NDArray[np.int_]) -> npt.NDArray:
+        return np.array([0.1 * x[0], 0.2 * x[1]])
     particle_changes = [np.array([-1, 1]), np.array([1, -1])]
     gillespie = Gillespie(
         init_particle_counts, rates_fun, particle_changes, 
@@ -115,7 +121,8 @@ def test_status_of_t_max_reached():
 def test_concentrations():
     # A <-> B
     init_particle_counts = np.array([100, 200])
-    rates_fun = lambda x: [0.1, 0.2]
+    def rates_fun(x: npt.NDArray[np.int_]) -> npt.NDArray:
+        return np.array([0.1, 0.2])
     particle_changes = [np.array([-1, 1]), np.array([1, -1])]
     volume = 1.0
     gillespie = Gillespie(
@@ -131,7 +138,8 @@ def test_concentrations():
 def test_gillespie_init_based_on_concentrations():
     # A <-> B
     init_concentrations = np.array([1e-4, 2e-4])
-    conc_rates_fun = lambda x: [0.1, 0.2]
+    def conc_rates_fun(x: npt.NDArray[np.int_]) -> npt.NDArray:
+        return np.array([0.1, 0.2])
     particle_changes = [np.array([-1, 1]), np.array([1, -1])]
     volume = 1.0
     gillespie = Gillespie.init_based_on_concentrations(
@@ -159,7 +167,8 @@ def test_with_example_reaction():
     # C = 2 * A0 * (1 - exp(-k * t))
     init_particle_counts = np.array([10000, 0, 0])
     k = 0.1
-    rates_fun = lambda x: [k * x[0]]
+    def rates_fun(x: npt.NDArray[np.int_]) -> npt.NDArray:
+        return np.array([k * x[0]])
     particle_changes = [np.array([-1, 1, 2])]
     gillespie = Gillespie(
         init_particle_counts, rates_fun, particle_changes, 
@@ -197,7 +206,8 @@ def test_with_example_reaction_by_plotting():
     # C = 2 * A0 * (1 - exp(-k * t))
     init_particle_counts = np.array([10000, 0, 0])
     k = 0.1
-    rates_fun = lambda x: [k * x[0]]
+    def rates_fun(x: npt.NDArray[np.int_]) -> npt.NDArray:
+        return np.array([k * x[0]])
     particle_changes = [np.array([-1, 1, 2])]
     gillespie = Gillespie(
         init_particle_counts, rates_fun, particle_changes, 


### PR DESCRIPTION
This pull request focuses on improving type safety and readability in the `nasap/simulation/tests/test_gillespie.py` file by replacing lambda functions with properly typed functions. The changes involve the use of `numpy.typing` for type annotations and converting lambda functions to named functions with explicit return types.

Key changes include:

Type safety improvements:
* Imported `numpy.typing` as `npt` to use for type annotations.
* Replaced lambda functions with named functions that use `npt.NDArray` for type annotations in various test functions:
  - `test_init`
  - `test_solve`
  - `test_step_count`
  - `test_status_of_max_iter_reached`
  - `test_status_of_total_rate_zero` [[1]](diffhunk://#diff-e0fc689b0543b0a2cd61c269a92e595be7b0575641f8d24c9f594948c7e2da04L82-R88) [[2]](diffhunk://#diff-e0fc689b0543b0a2cd61c269a92e595be7b0575641f8d24c9f594948c7e2da04L100-R106)
  - `test_status_of_t_max_reached` [[1]](diffhunk://#diff-e0fc689b0543b0a2cd61c269a92e595be7b0575641f8d24c9f594948c7e2da04L100-R106) [[2]](diffhunk://#diff-e0fc689b0543b0a2cd61c269a92e595be7b0575641f8d24c9f594948c7e2da04L118-R125)
  - `test_concentrations` [[1]](diffhunk://#diff-e0fc689b0543b0a2cd61c269a92e595be7b0575641f8d24c9f594948c7e2da04L118-R125) [[2]](diffhunk://#diff-e0fc689b0543b0a2cd61c269a92e595be7b0575641f8d24c9f594948c7e2da04L134-R142)
  - `test_gillespie_init_based_on_concentrations`
  - `test_with_example_reaction`
  - `test_with_example_reaction_by_plotting`