### PR TITLE
Remove unused imports

### DIFF
--- a/nasap/fitting/lmfit/minimizer.py
+++ b/nasap/fitting/lmfit/minimizer.py
@@ -1,11 +1,9 @@
-import inspect
-from collections.abc import Callable, Iterable
-from typing import Concatenate, ParamSpec, Protocol, TypeAlias, TypeVar
+from collections.abc import Callable
+from typing import Concatenate, ParamSpec
 
 import numpy.typing as npt
 from lmfit import Minimizer, Parameters
 
-from ..objective_func import make_objective_func_from_simulating_func
 from ..rss import calc_simulation_rss
 
 _P = ParamSpec('_P')

--- a/nasap/fitting/objective_func.py
+++ b/nasap/fitting/objective_func.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from typing import Concatenate
 
 import numpy.typing as npt

--- a/nasap/fitting/sample_data/sample_data.py
+++ b/nasap/fitting/sample_data/sample_data.py
@@ -1,6 +1,5 @@
 from collections.abc import Callable
-from typing import (Concatenate, Generic, NamedTuple, ParamSpec, TypeAlias,
-                    TypeVar)
+from typing import Concatenate, Generic, NamedTuple, ParamSpec, TypeVar
 
 import numpy as np
 import numpy.typing as npt

--- a/nasap/simulation/tests/test_simulating_func.py
+++ b/nasap/simulation/tests/test_simulating_func.py
@@ -1,9 +1,8 @@
-from typing import NamedTuple
 
 import numpy as np
 import numpy.typing as npt
 import pytest
-from hypothesis import example, given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 from scipy.integrate import solve_ivp


### PR DESCRIPTION
This pull request involves several changes to the `nasap` package, primarily focused on cleaning up imports and removing unused modules. These changes help streamline the codebase and improve maintainability. The most important changes include removing unused imports from various files.

Cleanup of imports:

* [`nasap/fitting/lmfit/minimizer.py`](diffhunk://#diff-ffe773745f7c6dc56daf9af6d52789a0cf22936d1635b04c0670f117523830d5L1-L8): Removed unused imports `inspect`, `Iterable`, `Protocol`, and `TypeAlias`.
* [`nasap/fitting/objective_func.py`](diffhunk://#diff-2cd6ba542a533e521a1eaa210666937f7289cfc6c9aa5690fa7e9f47f4c1821cL1-R1): Removed unused import `Mapping`.
* [`nasap/fitting/sample_data/sample_data.py`](diffhunk://#diff-4e1798a80b8ebc117c3b839ff8fc6c03c18874b20dd4409ec8d50cb0ebcacb81L2-R2): Removed unused imports `TypeAlias` and `NamedTuple`.
* [`nasap/simulation/tests/test_simulating_func.py`](diffhunk://#diff-70bb6146ab8aa36ad74bdf5e66d166d11f693754e828caa379a781809cc52d26L1-R5): Removed unused imports `NamedTuple`, `example`, and `settings`.