### PR TITLE
Use wildcard imports for `objective_func` and `rss` modules

### DIFF
--- a/nasap/fitting/__init__.py
+++ b/nasap/fitting/__init__.py
@@ -1,2 +1,2 @@
-from .objective_func import make_objective_func_from_simulating_func
-from .rss import calc_simulation_rss
+from .objective_func import *
+from .rss import *


### PR DESCRIPTION
This pull request includes changes to the `nasap/fitting/__init__.py` file to simplify the import statements by using wildcard imports.

Codebase simplification:

* [`nasap/fitting/__init__.py`](diffhunk://#diff-19caa9c48dea00d6fa943885bb770b1c7869f281ffd2dd7a3e7d556efe6e782eL1-R2): Changed specific imports to wildcard imports for `objective_func` and `rss` modules.