### PR TITLE
Add `unpack_args` option in objective function making

### DIFF
--- a/nasap/fitting/objective_func.py
+++ b/nasap/fitting/objective_func.py
@@ -12,6 +12,8 @@ def make_objective_func_from_simulating_func(
         simulating_func: Callable[
             Concatenate[npt.NDArray, npt.NDArray, ...], npt.NDArray],
         y0: npt.NDArray,
+        *,
+        unpack_args: bool = False
         ) -> Callable[[npt.NDArray], float]:
     """Make an objective function from a simulating function.
     
@@ -35,6 +37,11 @@ def make_objective_func_from_simulating_func(
         arguments are not supported.
     y0 : npt.NDArray, shape (m,)
         Initial conditions.
+    unpack_args : bool, optional
+        If True, the parameters (1D `npt.NDArray`) passed to the 
+        resulting objective function will be passed as unpacked arguments 
+        to the `simulating_func`. Otherwise, the parameters will be passed
+        as a single argument as is. Default is False.
 
     Returns
     -------
@@ -46,12 +53,17 @@ def make_objective_func_from_simulating_func(
             ``objective_func(param_values) -> rss``
         
         where ``param_values`` is a 1-D array with shape (p,) and ``rss`` is
-        the residual sum of squares (float). The parameters should be passed
-        in the same order as they are expected by the simulation function.
+        the residual sum of squares (float).
     """
-
-    def objective_func(param_values: npt.NDArray) -> float:
-        rss = calc_simulation_rss(tdata, ydata, simulating_func, y0, *param_values)
-        return rss
+    if unpack_args:
+        def objective_func(param_values: npt.NDArray) -> float:
+            rss = calc_simulation_rss(
+                tdata, ydata, simulating_func, y0, *param_values)  # unpack
+            return rss
+    else:
+        def objective_func(param_values: npt.NDArray) -> float:
+            rss = calc_simulation_rss(
+                tdata, ydata, simulating_func, y0, param_values)
+            return rss
     
     return objective_func

--- a/nasap/fitting/tests/test_objective_func.py
+++ b/nasap/fitting/tests/test_objective_func.py
@@ -12,12 +12,59 @@ def test_use_for_differential_evolution():
     sample = get_a_to_b_sample()
 
     objective_func = make_objective_func_from_simulating_func(
-        sample.t, sample.y, sample.simulating_func, sample.y0)
+        sample.t, sample.y, sample.simulating_func, sample.y0,
+        unpack_args=True)
 
     result = differential_evolution(objective_func, [(-3, 3)])
 
     assert result.success
     np.testing.assert_allclose(result.x, sample.params.log_k, atol=1e-3)
+
+
+def test_unpack_args():
+    # Imaginary simulating function with minimum at (0, 0)
+    def sim_func(t, y0, k1, k2):  # Receives unpacked arguments
+        return np.zeros((len(t), len(y0))) + k1**2 + k2**2
+    
+    # Imaginary data
+    tdata = np.array([0.0, 1.0, 2.0])
+    ydata = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
+    y0 = np.array([0.0, 0.0])
+    
+    # By specifying unpack_args=True, the array of the fitting parameters,
+    # i.e., np.array([k1, k2]), will be unpacked into k1 and k2
+    # before passing them to sim_func
+    objective_func = make_objective_func_from_simulating_func(
+        tdata, ydata, sim_func, y0, unpack_args=True)
+
+    result = differential_evolution(objective_func, [(-1, 1), (-1, 1)])
+
+    assert result.success
+    assert np.allclose(result.x, [0, 0])
+
+
+def test_not_unpack_args():
+    # Imaginary simulating function with minimum at (0, 0)
+    def sim_func(t, y0, ks):  # Receives packed arguments
+        k1 = ks[0]
+        k2 = ks[1]
+        return np.zeros((len(t), len(y0))) + k1**2 + k2**2
+    
+    # Imaginary data
+    tdata = np.array([0.0, 1.0, 2.0])
+    ydata = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
+    y0 = np.array([0.0, 0.0])
+    
+    # By specifying unpack_args=False, the array of the fitting parameters,
+    # i.e., np.array([k1, k2]), will be passed as a single argument ks
+    # to sim_func
+    objective_func = make_objective_func_from_simulating_func(
+        tdata, ydata, sim_func, y0, unpack_args=False)  # Do not unpack arguments
+
+    result = differential_evolution(objective_func, [(-1, 1), (-1, 1)])
+
+    assert result.success
+    assert np.allclose(result.x, [0, 0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request introduces an enhancement to the `make_objective_func_from_simulating_func` function in the `nasap/fitting/objective_func.py` file by adding an optional `unpack_args` parameter. It also includes new tests to verify the functionality of this enhancement.

Enhancements to `make_objective_func_from_simulating_func`:

* Added an `unpack_args` parameter to allow passing parameters as unpacked arguments to the `simulating_func` if set to `True`. This provides flexibility in how parameters are passed to the simulation function. [[1]](diffhunk://#diff-2cd6ba542a533e521a1eaa210666937f7289cfc6c9aa5690fa7e9f47f4c1821cR15-R16) [[2]](diffhunk://#diff-2cd6ba542a533e521a1eaa210666937f7289cfc6c9aa5690fa7e9f47f4c1821cR40-R44) [[3]](diffhunk://#diff-2cd6ba542a533e521a1eaa210666937f7289cfc6c9aa5690fa7e9f47f4c1821cL49-R66)

Tests for the new functionality:

* Updated the `test_use_for_differential_evolution` test to include the `unpack_args=True` parameter.
* Added `test_unpack_args` to verify the behavior when `unpack_args` is set to `True`, ensuring parameters are correctly unpacked.
* Added `test_not_unpack_args` to verify the behavior when `unpack_args` is set to `False`, ensuring parameters are passed as a single argument.