### PR TITLE
Refactor simulation function to use t_eval instead of dense_output

### DIFF
--- a/nasap/simulation/simulating_func.py
+++ b/nasap/simulation/simulating_func.py
@@ -79,8 +79,8 @@ def make_simulating_func_from_ode_rhs(
 
         sol = solve_ivp(
             ode_rhs_with_fixed_parameters, (t[0], t[-1]), y0,
-            dense_output=True)
+            t_eval=t)
 
-        return sol.sol(t).T
+        return sol.y.T
 
     return simulating_func

--- a/nasap/simulation/tests/test_simulating_func.py
+++ b/nasap/simulation/tests/test_simulating_func.py
@@ -21,8 +21,8 @@ def test_one_reaction():
     y0 = np.array([1, 0])
     k = 1
 
-    sol = solve_ivp(ode_rhs, (t[0], t[-1]), y0, args=(k,), dense_output=True)
-    expected = sol.sol(t).T
+    sol = solve_ivp(ode_rhs, (t[0], t[-1]), y0, args=(k,), t_eval=t)
+    expected = sol.y.T
 
     y = simulating_func(t, y0, k)
 
@@ -42,8 +42,8 @@ def test_two_reactions():
     k1 = 1
     k2 = 1
 
-    sol = solve_ivp(ode_rhs, (t[0], t[-1]), y0, args=(k1, k2), dense_output=True)
-    expected = sol.sol(t).T
+    sol = solve_ivp(ode_rhs, (t[0], t[-1]), y0, args=(k1, k2), t_eval=t)
+    expected = sol.y.T
 
     y = simulating_func(t, y0, k1, k2)
 
@@ -63,8 +63,8 @@ def test_reversible_reaction():
     k1 = 1
     k2 = 1
 
-    sol = solve_ivp(ode_rhs, (t[0], t[-1]), y0, args=(k1, k2), dense_output=True)
-    expected = sol.sol(t).T
+    sol = solve_ivp(ode_rhs, (t[0], t[-1]), y0, args=(k1, k2), t_eval=t)
+    expected = sol.y.T
 
     y = simulating_func(t, y0, k1, k2)
 
@@ -100,8 +100,8 @@ def test_simulating_func(t_y0_log_k_mat: tuple) -> None:
     
     sol = solve_ivp(
         ode_rhs_with_fixed_parameters, 
-        (t[0], t[-1]), y0, dense_output=True)
-    expected = sol.sol(t).T
+        (t[0], t[-1]), y0, t_eval=t)
+    expected = sol.y.T
 
     simulating_func = make_simulating_func_from_ode_rhs(ode_rhs)
 


### PR DESCRIPTION
This pull request includes changes to the `nasap/simulation/simulating_func.py` and `nasap/simulation/tests/test_simulating_func.py` files to modify how the ODE solver results are handled. The main changes involve replacing the `dense_output` parameter with the `t_eval` parameter in the `solve_ivp` function calls and updating the return values accordingly.

Changes in `nasap/simulation/simulating_func.py`:

* Modified `ode_rhs_with_fixed_parameters` to use the `t_eval` parameter instead of `dense_output` and updated the return value to `sol.y.T`.

Changes in `nasap/simulation/tests/test_simulating_func.py`:

* Updated `ode_rhs` function to use the `t_eval` parameter instead of `dense_output` and updated the expected result to `sol.y.T`.
* Updated `ode_rhs` function with two parameters (`k1`, `k2`) to use the `t_eval` parameter instead of `dense_output` and updated the expected result to `sol.y.T`. [[1]](diffhunk://#diff-70bb6146ab8aa36ad74bdf5e66d166d11f693754e828caa379a781809cc52d26L45-R46) [[2]](diffhunk://#diff-70bb6146ab8aa36ad74bdf5e66d166d11f693754e828caa379a781809cc52d26L66-R67)
* Updated `ode_rhs_with_fixed_parameters` to use the `t_eval` parameter instead of `dense_output` and updated the expected result to `sol.y.T`.