### PR TITLE
Add method, rtol, and atol params to make_simulating_func_from_ode_rhs

### DIFF
--- a/nasap/simulation/simulating_func.py
+++ b/nasap/simulation/simulating_func.py
@@ -20,7 +20,8 @@ class SimulatingFunc(Generic[_P], Protocol):
 
 
 def make_simulating_func_from_ode_rhs(
-        ode_rhs: Callable[Concatenate[float, npt.NDArray, _P], npt.NDArray]
+        ode_rhs: Callable[Concatenate[float, npt.NDArray, _P], npt.NDArray],
+        method: str = 'RK45', rtol: float = 1e-3, atol: float = 1e-6
         ) -> SimulatingFunc[_P]:
     """Make a simulating function from an ODE right-hand side function.
 
@@ -43,6 +44,15 @@ def make_simulating_func_from_ode_rhs(
         ``dydt`` is the derivative of the dependent variable (1-D
         array, shape (m,)). The names of ``t`` and ``y`` can be
         different.
+    method: str, optional
+        The method to use for the `solve_ivp` function. Default is
+        'RK45'.
+    rtol: float, optional
+        The relative tolerance for the `solve_ivp` function. Default
+        is 1e-3.
+    atol: float, optional
+        The absolute tolerance for the `solve_ivp` function. Default
+        is 1e-6.
 
     Returns
     -------
@@ -76,10 +86,10 @@ def make_simulating_func_from_ode_rhs(
         def ode_rhs_with_fixed_parameters(
                 t: float, y: npt.NDArray) -> npt.NDArray:
             return ode_rhs(t, y, *args, **kwargs)
-
+        
         sol = solve_ivp(
             ode_rhs_with_fixed_parameters, (t[0], t[-1]), y0,
-            t_eval=t)
+            t_eval=t, method=method, rtol=rtol, atol=atol)
 
         return sol.y.T
 

--- a/nasap/simulation/tests/test_simulating_func.py
+++ b/nasap/simulation/tests/test_simulating_func.py
@@ -110,5 +110,48 @@ def test_simulating_func(t_y0_log_k_mat: tuple) -> None:
     np.testing.assert_allclose(y, expected, rtol=1e-3, atol=1e-6)
 
 
+def test_custom_method():
+    def ode_rhs(t: float, y: npt.NDArray, k: float) -> npt.NDArray:
+        return np.array([-k * y[0], k * y[0]])
+
+    simulating_func = make_simulating_func_from_ode_rhs(
+        ode_rhs, method='RK23')
+
+    t = np.logspace(-3, 1, 12)
+    y0 = np.array([1, 0])
+    k = 1
+
+    sol = solve_ivp(
+        ode_rhs, (t[0], t[-1]), y0, args=(k,), t_eval=t, method='RK23')
+    expected = sol.y.T
+
+    y = simulating_func(t, y0, k)
+
+    assert y.shape == (len(t), len(y0))
+    np.testing.assert_allclose(y, expected, rtol=1e-3, atol=1e-6)
+
+
+def test_custom_rtol_atol():
+    def ode_rhs(t: float, y: npt.NDArray, k: float) -> npt.NDArray:
+        return np.array([-k * y[0], k * y[0]])
+
+    simulating_func = make_simulating_func_from_ode_rhs(
+        ode_rhs, rtol=1e-6, atol=1e-9)
+
+    t = np.logspace(-3, 1, 12)
+    y0 = np.array([1, 0])
+    k = 1
+
+    sol = solve_ivp(
+        ode_rhs, (t[0], t[-1]), y0, args=(k,), t_eval=t, 
+        rtol=1e-6, atol=1e-9)
+    expected = sol.y.T
+
+    y = simulating_func(t, y0, k)
+
+    assert y.shape == (len(t), len(y0))
+    np.testing.assert_allclose(y, expected, rtol=1e-3, atol=1e-6)
+
+
 if __name__ == "__main__":
     pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces enhancements to the `make_simulating_func_from_ode_rhs` function in the `nasap/simulation/simulating_func.py` file, adding new parameters for numerical integration methods and tolerances. Additionally, new tests have been added to validate these changes. The most important changes are summarized below:

Enhancements to `make_simulating_func_from_ode_rhs` function:

* Added optional parameters `method`, `rtol`, and `atol` to the `make_simulating_func_from_ode_rhs` function to allow customization of the numerical integration method and tolerances. (`nasap/simulation/simulating_func.py`) [[1]](diffhunk://#diff-66eab44522c5e88fb61c43079e16aa0995508bae20c9192f084c39a94da0b973L23-R24) [[2]](diffhunk://#diff-66eab44522c5e88fb61c43079e16aa0995508bae20c9192f084c39a94da0b973R47-R55)
* Updated the call to `solve_ivp` within `make_simulating_func_from_ode_rhs` to use the new `method`, `rtol`, and `atol` parameters. (`nasap/simulation/simulating_func.py`)

New tests to validate enhancements:

* Added `test_custom_method` to verify that the `make_simulating_func_from_ode_rhs` function correctly uses a custom integration method. (`nasap/simulation/tests/test_simulating_func.py`)
* Added `test_custom_rtol_atol` to check that the `make_simulating_func_from_ode_rhs` function correctly applies custom relative and absolute tolerances. (`nasap/simulation/tests/test_simulating_func.py`)