### PR TITLE
Fix exponentiation in create_ode_rhs to use float

### DIFF
--- a/nasap/ode_creation/reactions_to_ode.py
+++ b/nasap/ode_creation/reactions_to_ode.py
@@ -52,7 +52,7 @@ def create_ode_rhs(
         # y: concentrations of assemblies, shape: (n,)
         # log_k_of_rxn_kinds: log(k) of each reaction kind, shape: (k,)
 
-        k_of_rxn_kinds = 10**log_k_of_rxn_kinds  # shape: (k,)
+        k_of_rxn_kinds = 10.0**log_k_of_rxn_kinds  # shape: (k,)
         ks = rxn_to_kind @ k_of_rxn_kinds  # shape: (m,)
 
         # First, determine the rate of the reaction occurrences.


### PR DESCRIPTION
This pull request includes a small change to the `ode_rhs` function in the `nasap/ode_creation/reactions_to_ode.py` file. The change ensures that the exponentiation operation uses a float base for more precise calculations.

* [`nasap/ode_creation/reactions_to_ode.py`](diffhunk://#diff-8ded9d74daa271badceb3f0a1eabc30c46dad8ed8c90844c8ad57dfe805fcaedL55-R55): Changed the base of the exponentiation from `10` to `10.0` for the `k_of_rxn_kinds` calculation.