### PR TITLE
Refactor Reaction class and related functions to use generic types

### DIFF
--- a/nasap/ode_creation/lib/particle_change.py
+++ b/nasap/ode_creation/lib/particle_change.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterable
+
 import numpy as np
 import numpy.typing as npt
 
@@ -8,17 +10,19 @@ from nasap.ode_creation.reaction_class import Reaction
 # k: number of reaction kinds
 
 def calc_particle_change(
-        assems: list[int], reactions: list[Reaction]
+        number_of_assems: int, reactions: Iterable[Reaction]
         ) -> npt.NDArray:  # shape (m, n)
-    consumed_count = calc_consumed_count(assems, reactions)
-    produced_count = calc_produced_count(assems, reactions)
+    consumed_count = calc_consumed_count(number_of_assems, reactions)
+    produced_count = calc_produced_count(number_of_assems, reactions)
     return produced_count - consumed_count
 
 
 def calc_consumed_count(
-        assems: list[int], reactions: list[Reaction]
+        number_of_assems: int, reactions: Iterable[Reaction]
         ) -> npt.NDArray:  # shape (m, n)
-    consumed_count = np.zeros((len(reactions), len(assems)), dtype=int)
+    reactions = list(reactions)
+    consumed_count = np.zeros(
+        (len(reactions), number_of_assems), dtype=int)
     for i, reaction in enumerate(reactions):
         for assem in reaction.reactants:
             consumed_count[i, assem] += 1
@@ -26,9 +30,11 @@ def calc_consumed_count(
 
 
 def calc_produced_count(
-        assems: list[int], reactions: list[Reaction]
+        number_of_assems: int, reactions: Iterable[Reaction]
         ) -> npt.NDArray:  # shape (m, n)
-    produced_count = np.zeros((len(reactions), len(assems)), dtype=int)
+    reactions = list(reactions)
+    produced_count = np.zeros(
+        (len(reactions), number_of_assems), dtype=int)
     for i, reaction in enumerate(reactions):
         for assem in reaction.products:
             produced_count[i, assem] += 1

--- a/nasap/ode_creation/lib/tests/test_particle_change.py
+++ b/nasap/ode_creation/lib/tests/test_particle_change.py
@@ -8,64 +8,64 @@ from nasap.ode_creation.reaction_class import Reaction
 
 def test_1_to_1():
     # A -> B  (k)
-    assemblies = [0, 1]
+    number_of_assems = 2
     reaction = Reaction(
         reactants=[0], products=[1], reaction_kind=0, 
         duplicate_count=1)
     np.testing.assert_array_equal(
-        calc_consumed_count(assemblies, [reaction]), [[1, 0]])
+        calc_consumed_count(number_of_assems, [reaction]), [[1, 0]])
     np.testing.assert_array_equal(
-        calc_produced_count(assemblies, [reaction]), [[0, 1]])
+        calc_produced_count(number_of_assems, [reaction]), [[0, 1]])
     np.testing.assert_array_equal(
-        calc_particle_change(assemblies, [reaction]), [[-1, 1]])
+        calc_particle_change(number_of_assems, [reaction]), [[-1, 1]])
 
 
 def test_2_to_1():
     # A + A -> B  (k)
-    assemblies = [0, 1]
+    number_of_assems = 2
     reaction = Reaction(
         reactants=[0, 0], products=[1], reaction_kind=0, 
         duplicate_count=2)
     np.testing.assert_array_equal(
-        calc_consumed_count(assemblies, [reaction]), [[2, 0]])
+        calc_consumed_count(number_of_assems, [reaction]), [[2, 0]])
     np.testing.assert_array_equal(
-        calc_produced_count(assemblies, [reaction]), [[0, 1]])
+        calc_produced_count(number_of_assems, [reaction]), [[0, 1]])
     np.testing.assert_array_equal(
-        calc_particle_change(assemblies, [reaction]), [[-2, 1]])
+        calc_particle_change(number_of_assems, [reaction]), [[-2, 1]])
 
 
 def test_1_to_2():
     # A -> B + B  (k)
-    assemblies = [0, 1]
+    number_of_assems = 2
     reaction = Reaction(
         reactants=[0], products=[1, 1], reaction_kind=0, 
         duplicate_count=1)
     np.testing.assert_array_equal(
-        calc_consumed_count(assemblies, [reaction]), [[1, 0]])
+        calc_consumed_count(number_of_assems, [reaction]), [[1, 0]])
     np.testing.assert_array_equal(
-        calc_produced_count(assemblies, [reaction]), [[0, 2]])
+        calc_produced_count(number_of_assems, [reaction]), [[0, 2]])
     np.testing.assert_array_equal(
-        calc_particle_change(assemblies, [reaction]), [[-1, 2]])
+        calc_particle_change(number_of_assems, [reaction]), [[-1, 2]])
 
 
 def test_2_to_2():
     # A + A -> B + B  (k)
-    assemblies = [0, 1]
+    number_of_assems = 2
     reaction = Reaction(
         reactants=[0, 0], products=[1, 1], reaction_kind=0, 
         duplicate_count=2)
     np.testing.assert_array_equal(
-        calc_consumed_count(assemblies, [reaction]), [[2, 0]])
+        calc_consumed_count(number_of_assems, [reaction]), [[2, 0]])
     np.testing.assert_array_equal(
-        calc_produced_count(assemblies, [reaction]), [[0, 2]])
+        calc_produced_count(number_of_assems, [reaction]), [[0, 2]])
     np.testing.assert_array_equal(
-        calc_particle_change(assemblies, [reaction]), [[-2, 2]])
+        calc_particle_change(number_of_assems, [reaction]), [[-2, 2]])
     
 
 def test_reversible():
     # A -> 2B  (k1)
     # 2B -> A  (k2)
-    assemblies = [0, 1]
+    number_of_assems = 2
     reactions = [
         Reaction(
             reactants=[0], products=[1, 1], reaction_kind=0, 
@@ -75,11 +75,11 @@ def test_reversible():
             duplicate_count=2)
         ]
     np.testing.assert_array_equal(
-        calc_consumed_count(assemblies, reactions), [[1, 0], [0, 2]])
+        calc_consumed_count(number_of_assems, reactions), [[1, 0], [0, 2]])
     np.testing.assert_array_equal(
-        calc_produced_count(assemblies, reactions), [[0, 2], [1, 0]])
+        calc_produced_count(number_of_assems, reactions), [[0, 2], [1, 0]])
     np.testing.assert_array_equal(
-        calc_particle_change(assemblies, reactions), [[-1, 2], [1, -2]])
+        calc_particle_change(number_of_assems, reactions), [[-1, 2], [1, -2]])
 
 
 if __name__ == '__main__':

--- a/nasap/ode_creation/reaction_class.py
+++ b/nasap/ode_creation/reaction_class.py
@@ -1,8 +1,8 @@
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import Generic, TypeVar
 
-_T_co = TypeVar('_T_co', covariant=True)
-_S_co = TypeVar('_S_co', covariant=True)
+_T_co = TypeVar('_T_co', covariant=True)  # type of assembly
+_S_co = TypeVar('_S_co', covariant=True)  # type of reaction kind
 
 
 class Reaction(Generic[_T_co, _S_co]):
@@ -47,3 +47,21 @@ class Reaction(Generic[_T_co, _S_co]):
             self._duplicate_count == other._duplicate_count and
             self._reaction_kind == other._reaction_kind
             )
+
+
+def convert_reaction_to_use_index(
+        descriptive_reaction: Reaction[_T_co, _S_co],
+        assem_id_to_index: Mapping[_T_co, int],
+        reaction_kind_id_to_index: Mapping[_S_co, int],
+        ) -> Reaction[int, int]:
+    reactant_indices = [
+        assem_id_to_index[assem] for assem in descriptive_reaction.reactants]
+    product_indices = [
+        assem_id_to_index[assem] for assem in descriptive_reaction.products]
+    reaction_kind_index = reaction_kind_id_to_index[
+        descriptive_reaction.reaction_kind]
+    return Reaction(
+        reactants=reactant_indices,
+        products=product_indices,
+        reaction_kind=reaction_kind_index,
+        duplicate_count=descriptive_reaction.duplicate_count)

--- a/nasap/ode_creation/tests/test_reactions_to_ode.py
+++ b/nasap/ode_creation/tests/test_reactions_to_ode.py
@@ -55,7 +55,7 @@ def test_basic():
         k = 10**log_k
         return np.array([-k * y[0], k * y[0]])
 
-    ode_rhs = create_ode_rhs(assemblies, reactions, reaction_kinds)
+    ode_rhs = create_ode_rhs(assemblies, reaction_kinds, reactions)
 
     checker = OdeRhsEquivalenceChecker(ode_rhs, expected_ode_rhs)
     # parameters: t, y, log_k_of_rxn_kinds
@@ -83,7 +83,7 @@ def test_reversible():
         k2 = 10**log_k_of_rxn_kinds[1]
         return np.array([-k1 * y[0] + k2 * y[1], k1 * y[0] - k2 * y[1]])
     
-    ode_rhs = create_ode_rhs(assemblies, reactions, reaction_kinds)
+    ode_rhs = create_ode_rhs(assemblies, reaction_kinds, reactions)
 
     checker = OdeRhsEquivalenceChecker(ode_rhs, expected_ode_rhs)
     checker.check(0, np.array([1, 0]), np.array([0, 0]))
@@ -109,7 +109,7 @@ def test_chain():
         k2 = 10**log_k_of_rxn_kinds[1]
         return np.array([-k1 * y[0], k1 * y[0] - k2 * y[1], k2 * y[1]])
     
-    ode_rhs = create_ode_rhs(assemblies, reactions, [0, 1])
+    ode_rhs = create_ode_rhs(assemblies, [0, 1], reactions)
 
     checker = OdeRhsEquivalenceChecker(ode_rhs, expected_ode_rhs)
     checker.check(0, np.array([1, 0, 0]), np.array([0, 0]))
@@ -141,7 +141,7 @@ def test_competition():
         return np.array(
             [-k1 * y[0] - k2 * y[0], k1 * y[0], k2 * y[0]])
     
-    ode_rhs = create_ode_rhs(assemblies, reactions, [0, 1])
+    ode_rhs = create_ode_rhs(assemblies, [0, 1], reactions)
 
     checker = OdeRhsEquivalenceChecker(ode_rhs, expected_ode_rhs)
     checker.check(0, np.array([1, 0, 0]), np.array([0, 0]))
@@ -168,7 +168,7 @@ def test_duplicate_count():
         k = 10**rxn_kind_to_log_k[0]
         return np.array([-2 * k * y[0], 2 * k * y[0]])
     
-    ode_rhs = create_ode_rhs(assemblies, reactions, reaction_kinds)
+    ode_rhs = create_ode_rhs(assemblies, reaction_kinds, reactions)
 
     checker = OdeRhsEquivalenceChecker(ode_rhs, expected_ode_rhs)
     checker.check(0, np.array([1, 0]), np.array([0]))
@@ -195,7 +195,7 @@ def test_hetero_2_to_1():
         return np.array(
             [-k1 * y[0] * y[1], -k1 * y[0] * y[1], k1 * y[0] * y[1]])
     
-    ode_rhs = create_ode_rhs(assemblies, reactions, reaction_kinds)
+    ode_rhs = create_ode_rhs(assemblies, reaction_kinds, reactions)
 
     checker = OdeRhsEquivalenceChecker(ode_rhs, expected_ode_rhs)
     checker.check(0, np.array([1, 1, 0]), np.array([0]))
@@ -232,7 +232,7 @@ def test_homo_2_to_1():
         return np.array(
             [-2 * 2 * k1 * y[0]**2, 2 * k1 * y[0]**2])
 
-    ode_rhs = create_ode_rhs(assemblies, reactions, reaction_kinds)
+    ode_rhs = create_ode_rhs(assemblies, reaction_kinds, reactions)
 
     checker = OdeRhsEquivalenceChecker(ode_rhs, expected_ode_rhs)
     checker.check(0, np.array([1, 0]), np.array([0]))
@@ -258,7 +258,7 @@ def test_1_to_homo_2():
         return np.array(
             [-k1 * y[0], 2 * k1 * y[0]])
 
-    ode_rhs = create_ode_rhs(assemblies, reactions, reaction_kinds)
+    ode_rhs = create_ode_rhs(assemblies, reaction_kinds, reactions)
 
     checker = OdeRhsEquivalenceChecker(ode_rhs, expected_ode_rhs)
     checker.check(0, np.array([1, 0]), np.array([0]))
@@ -284,7 +284,7 @@ def test_homo_2_to_homo_2():
         return np.array(
             [-2 * k1 * y[0]**2, 2 * k1 * y[0]**2])
 
-    ode_rhs = create_ode_rhs(assemblies, reactions, reaction_kinds)
+    ode_rhs = create_ode_rhs(assemblies, reaction_kinds, reactions)
 
     checker = OdeRhsEquivalenceChecker(ode_rhs, expected_ode_rhs)
     checker.check(0, np.array([1, 0]), np.array([0]))
@@ -316,7 +316,7 @@ def test_homo_2_to_1_reversible():
             [-2 * k1 * y[0]**2 + 2 * k2 * y[1], 
              k1 * y[0]**2 - k2 * y[1]])
     
-    ode_rhs = create_ode_rhs(assemblies, reactions, [0, 1])
+    ode_rhs = create_ode_rhs(assemblies, [0, 1], reactions)
 
     checker = OdeRhsEquivalenceChecker(ode_rhs, expected_ode_rhs)
     checker.check(0, np.array([1, 0]), np.array([0, 0]))


### PR DESCRIPTION
This pull request includes several changes to improve the handling of particle changes, reactions, and ODE calculations in the `nasap/ode_creation` module. The most important changes include modifying function parameters to use more appropriate types, adding a new utility function for converting reactions, and updating tests to reflect these changes.

### Improvements to function parameters and types:
* [`nasap/ode_creation/lib/particle_change.py`](diffhunk://#diff-41576f7c63af481d72f7d47927ed3e5a576a444aa2e44548c48757e098ff2027L11-R37): Changed parameters from `list[int]` to `int` and `Iterable[Reaction]` for better type safety and performance.
* [`nasap/ode_creation/reactions_to_ode.py`](diffhunk://#diff-8ded9d74daa271badceb3f0a1eabc30c46dad8ed8c90844c8ad57dfe805fcaedL21-R70): Updated `create_ode_rhs` function to use `Sequence` for `assemblies` and `reaction_kinds`, and added detailed docstrings.

### New utility function:
* [`nasap/ode_creation/reaction_class.py`](diffhunk://#diff-39831b1fbf0f55660b36bc7e53f918e482235a2202513eb6e07f00682bd31ba4R50-R67): Added `convert_reaction_to_use_index` function to convert reactions to use indices instead of descriptive IDs.

### Updates to tests:
* [`nasap/ode_creation/lib/tests/test_particle_change.py`](diffhunk://#diff-1bd4a1c3c4a2cdf3d19f020e22f8821c99db098d2cc7ac56c3856f54e983ea26L11-R68): Updated tests to use `number_of_assems` instead of `assemblies`.
* [`nasap/ode_creation/tests/test_reactions_to_ode.py`](diffhunk://#diff-bf1e673d4cc6b6eb25fa7cfa20af946cb023e74ec4c90919b12adb4fa75102ffL58-R58): Modified tests to reflect changes in `create_ode_rhs` parameter order and types. [[1]](diffhunk://#diff-bf1e673d4cc6b6eb25fa7cfa20af946cb023e74ec4c90919b12adb4fa75102ffL58-R58) [[2]](diffhunk://#diff-bf1e673d4cc6b6eb25fa7cfa20af946cb023e74ec4c90919b12adb4fa75102ffL86-R86) [[3]](diffhunk://#diff-bf1e673d4cc6b6eb25fa7cfa20af946cb023e74ec4c90919b12adb4fa75102ffL112-R112) [[4]](diffhunk://#diff-bf1e673d4cc6b6eb25fa7cfa20af946cb023e74ec4c90919b12adb4fa75102ffL144-R144) [[5]](diffhunk://#diff-bf1e673d4cc6b6eb25fa7cfa20af946cb023e74ec4c90919b12adb4fa75102ffL171-R171) [[6]](diffhunk://#diff-bf1e673d4cc6b6eb25fa7cfa20af946cb023e74ec4c90919b12adb4fa75102ffL198-R198) [[7]](diffhunk://#diff-bf1e673d4cc6b6eb25fa7cfa20af946cb023e74ec4c90919b12adb4fa75102ffL235-R235) [[8]](diffhunk://#diff-bf1e673d4cc6b6eb25fa7cfa20af946cb023e74ec4c90919b12adb4fa75102ffL261-R261) [[9]](diffhunk://#diff-bf1e673d4cc6b6eb25fa7cfa20af946cb023e74ec4c90919b12adb4fa75102ffL287-R287) [[10]](diffhunk://#diff-bf1e673d4cc6b6eb25fa7cfa20af946cb023e74ec4c90919b12adb4fa75102ffL319-R319)