### PR TITLE
Refactor convert_reaction_to_use_index to use Sequence for IDs

### DIFF
--- a/nasap/ode_creation/reaction_class.py
+++ b/nasap/ode_creation/reaction_class.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Sequence
 from typing import Generic, TypeVar
 
 _T_co = TypeVar('_T_co', covariant=True)  # type of assembly
@@ -51,15 +51,20 @@ class Reaction(Generic[_T_co, _S_co]):
 
 def convert_reaction_to_use_index(
         descriptive_reaction: Reaction[_T_co, _S_co],
-        assem_id_to_index: Mapping[_T_co, int],
-        reaction_kind_id_to_index: Mapping[_S_co, int],
+        assem_ids: Sequence[_T_co],
+        reaction_kind_ids: Sequence[_S_co],
         ) -> Reaction[int, int]:
+    assem_id_to_index = {assem: i for i, assem in enumerate(assem_ids)}
+    reaction_kind_id_to_index = {
+        kind: i for i, kind in enumerate(reaction_kind_ids)}
+    
     reactant_indices = [
         assem_id_to_index[assem] for assem in descriptive_reaction.reactants]
     product_indices = [
         assem_id_to_index[assem] for assem in descriptive_reaction.products]
     reaction_kind_index = reaction_kind_id_to_index[
         descriptive_reaction.reaction_kind]
+    
     return Reaction(
         reactants=reactant_indices,
         products=product_indices,


### PR DESCRIPTION
This pull request includes changes to the `nasap/ode_creation/reaction_class.py` file to improve type consistency and refactor the `convert_reaction_to_use_index` function. The most important changes include replacing `Mapping` with `Sequence` and refactoring the function to create index mappings from sequences.

Type consistency improvements:

* [`nasap/ode_creation/reaction_class.py`](diffhunk://#diff-39831b1fbf0f55660b36bc7e53f918e482235a2202513eb6e07f00682bd31ba4L1-R1): Replaced `Mapping` with `Sequence` in the import statement to ensure type consistency across the module.

Function refactoring:

* [`nasap/ode_creation/reaction_class.py`](diffhunk://#diff-39831b1fbf0f55660b36bc7e53f918e482235a2202513eb6e07f00682bd31ba4L54-R67): Refactored the `convert_reaction_to_use_index` function to accept sequences (`assem_ids` and `reaction_kind_ids`) and create index mappings from these sequences. This change simplifies the function's interface and improves readability.