### PR TITLE
Update reactions_to_ode to use generic types

### DIFF
--- a/nasap/ode_creation/lib/particle_change.py
+++ b/nasap/ode_creation/lib/particle_change.py
@@ -1,41 +1,56 @@
-from collections.abc import Iterable
+from collections.abc import Hashable, Sequence
+from typing import Any, TypeVar
 
 import numpy as np
 import numpy.typing as npt
 
 from nasap.ode_creation.reaction_class import Reaction
 
+_T = TypeVar('_T', bound=Hashable)
+
 # n: number of assemblies
 # m: number of reactions
 # k: number of reaction kinds
 
 def calc_particle_change(
-        number_of_assems: int, reactions: Iterable[Reaction]
+        assemblies: Sequence[_T], reactions: Sequence[Reaction[_T, Any]]
         ) -> npt.NDArray:  # shape (m, n)
-    consumed_count = calc_consumed_count(number_of_assems, reactions)
-    produced_count = calc_produced_count(number_of_assems, reactions)
+    assemblies = list(assemblies)
+    reactions = list(reactions)
+    consumed_count = calc_consumed_count(assemblies, reactions)
+    produced_count = calc_produced_count(assemblies, reactions)
     return produced_count - consumed_count
 
 
 def calc_consumed_count(
-        number_of_assems: int, reactions: Iterable[Reaction]
+        assemblies: Sequence[_T], reactions: Sequence[Reaction[_T, Any]]
         ) -> npt.NDArray:  # shape (m, n)
+    assemblies = list(assemblies)
     reactions = list(reactions)
-    consumed_count = np.zeros(
-        (len(reactions), number_of_assems), dtype=int)
+    assem_to_index = {assem: i for i, assem in enumerate(assemblies)}
+
+    consumed_count = np.zeros((len(reactions), len(assemblies)), dtype=int)
+
     for i, reaction in enumerate(reactions):
         for assem in reaction.reactants:
-            consumed_count[i, assem] += 1
+            assem_index = assem_to_index[assem]
+            consumed_count[i, assem_index] += 1
+
     return consumed_count
 
 
 def calc_produced_count(
-        number_of_assems: int, reactions: Iterable[Reaction]
+        assemblies: Sequence[_T], reactions: Sequence[Reaction[_T, Any]]
         ) -> npt.NDArray:  # shape (m, n)
+    assemblies = list(assemblies)
     reactions = list(reactions)
-    produced_count = np.zeros(
-        (len(reactions), number_of_assems), dtype=int)
+    assem_to_index = {assem: i for i, assem in enumerate(assemblies)}
+
+    produced_count = np.zeros((len(reactions), len(assemblies)), dtype=int)
+
     for i, reaction in enumerate(reactions):
         for assem in reaction.products:
-            produced_count[i, assem] += 1
+            assem_index = assem_to_index[assem]
+            produced_count[i, assem_index] += 1
+
     return produced_count

--- a/nasap/ode_creation/lib/tests/test_particle_change.py
+++ b/nasap/ode_creation/lib/tests/test_particle_change.py
@@ -8,78 +8,78 @@ from nasap.ode_creation.reaction_class import Reaction
 
 def test_1_to_1():
     # A -> B  (k)
-    number_of_assems = 2
+    assems = ['A', 'B']
     reaction = Reaction(
-        reactants=[0], products=[1], reaction_kind=0, 
+        reactants=['A'], products=['B'], reaction_kind=0, 
         duplicate_count=1)
     np.testing.assert_array_equal(
-        calc_consumed_count(number_of_assems, [reaction]), [[1, 0]])
+        calc_consumed_count(assems, [reaction]), [[1, 0]])
     np.testing.assert_array_equal(
-        calc_produced_count(number_of_assems, [reaction]), [[0, 1]])
+        calc_produced_count(assems, [reaction]), [[0, 1]])
     np.testing.assert_array_equal(
-        calc_particle_change(number_of_assems, [reaction]), [[-1, 1]])
+        calc_particle_change(assems, [reaction]), [[-1, 1]])
 
 
 def test_2_to_1():
     # A + A -> B  (k)
-    number_of_assems = 2
+    assems = ['A', 'B']
     reaction = Reaction(
-        reactants=[0, 0], products=[1], reaction_kind=0, 
+        reactants=['A', 'A'], products=['B'], reaction_kind=0, 
         duplicate_count=2)
     np.testing.assert_array_equal(
-        calc_consumed_count(number_of_assems, [reaction]), [[2, 0]])
+        calc_consumed_count(assems, [reaction]), [[2, 0]])
     np.testing.assert_array_equal(
-        calc_produced_count(number_of_assems, [reaction]), [[0, 1]])
+        calc_produced_count(assems, [reaction]), [[0, 1]])
     np.testing.assert_array_equal(
-        calc_particle_change(number_of_assems, [reaction]), [[-2, 1]])
+        calc_particle_change(assems, [reaction]), [[-2, 1]])
 
 
 def test_1_to_2():
     # A -> B + B  (k)
-    number_of_assems = 2
+    assems = ['A', 'B']
     reaction = Reaction(
-        reactants=[0], products=[1, 1], reaction_kind=0, 
+        reactants=['A'], products=['B', 'B'], reaction_kind=0,
         duplicate_count=1)
     np.testing.assert_array_equal(
-        calc_consumed_count(number_of_assems, [reaction]), [[1, 0]])
+        calc_consumed_count(assems, [reaction]), [[1, 0]])
     np.testing.assert_array_equal(
-        calc_produced_count(number_of_assems, [reaction]), [[0, 2]])
+        calc_produced_count(assems, [reaction]), [[0, 2]])
     np.testing.assert_array_equal(
-        calc_particle_change(number_of_assems, [reaction]), [[-1, 2]])
+        calc_particle_change(assems, [reaction]), [[-1, 2]])
 
 
 def test_2_to_2():
     # A + A -> B + B  (k)
-    number_of_assems = 2
+    assems = ['A', 'B']
     reaction = Reaction(
-        reactants=[0, 0], products=[1, 1], reaction_kind=0, 
+        reactants=['A', 'A'], products=['B', 'B'], reaction_kind=0,
         duplicate_count=2)
     np.testing.assert_array_equal(
-        calc_consumed_count(number_of_assems, [reaction]), [[2, 0]])
+        calc_consumed_count(assems, [reaction]), [[2, 0]])
     np.testing.assert_array_equal(
-        calc_produced_count(number_of_assems, [reaction]), [[0, 2]])
+        calc_produced_count(assems, [reaction]), [[0, 2]])
     np.testing.assert_array_equal(
-        calc_particle_change(number_of_assems, [reaction]), [[-2, 2]])
+        calc_particle_change(assems, [reaction]), [[-2, 2]])
     
 
 def test_reversible():
     # A -> 2B  (k1)
     # 2B -> A  (k2)
-    number_of_assems = 2
+    assems = ['A', 'B']
     reactions = [
         Reaction(
-            reactants=[0], products=[1, 1], reaction_kind=0, 
+            reactants=['A'], products=['B', 'B'], reaction_kind=0,
             duplicate_count=1),
         Reaction(
-            reactants=[1, 1], products=[0], reaction_kind=1, 
+            reactants=['B', 'B'], products=['A'], reaction_kind=1,
             duplicate_count=2)
         ]
     np.testing.assert_array_equal(
-        calc_consumed_count(number_of_assems, reactions), [[1, 0], [0, 2]])
+        calc_consumed_count(assems, reactions), [[1, 0], [0, 2]])
     np.testing.assert_array_equal(
-        calc_produced_count(number_of_assems, reactions), [[0, 2], [1, 0]])
+        calc_produced_count(assems, reactions), [[0, 2], [1, 0]])
     np.testing.assert_array_equal(
-        calc_particle_change(number_of_assems, reactions), [[-1, 2], [1, -2]])
+        calc_particle_change(assems, reactions), [[-1, 2], [1, -2]])
 
 
 if __name__ == '__main__':

--- a/nasap/ode_creation/reaction_class.py
+++ b/nasap/ode_creation/reaction_class.py
@@ -47,26 +47,3 @@ class Reaction(Generic[_T_co, _S_co]):
             self._duplicate_count == other._duplicate_count and
             self._reaction_kind == other._reaction_kind
             )
-
-
-def convert_reaction_to_use_index(
-        descriptive_reaction: Reaction[_T_co, _S_co],
-        assem_ids: Sequence[_T_co],
-        reaction_kind_ids: Sequence[_S_co],
-        ) -> Reaction[int, int]:
-    assem_id_to_index = {assem: i for i, assem in enumerate(assem_ids)}
-    reaction_kind_id_to_index = {
-        kind: i for i, kind in enumerate(reaction_kind_ids)}
-    
-    reactant_indices = [
-        assem_id_to_index[assem] for assem in descriptive_reaction.reactants]
-    product_indices = [
-        assem_id_to_index[assem] for assem in descriptive_reaction.products]
-    reaction_kind_index = reaction_kind_id_to_index[
-        descriptive_reaction.reaction_kind]
-    
-    return Reaction(
-        reactants=reactant_indices,
-        products=product_indices,
-        reaction_kind=reaction_kind_index,
-        duplicate_count=descriptive_reaction.duplicate_count)

--- a/nasap/ode_creation/tests/test_reactions_to_ode.py
+++ b/nasap/ode_creation/tests/test_reactions_to_ode.py
@@ -325,5 +325,29 @@ def test_homo_2_to_1_reversible():
     checker.check(0, np.array([1, 0]), np.array([2, 1]))
 
 
+def test_str_assem_ids():
+    # A -> B  (k)
+    assemblies = ['A', 'B']
+    reactions = [
+        Reaction(
+            reactants=['A'], products=['B'], reaction_kind='k', 
+            duplicate_count=1)
+        ]
+    reaction_kinds = ['k']
+    
+    def expected_ode_rhs(t, y, log_k_of_rxn_kinds):
+        log_k, = log_k_of_rxn_kinds
+        k = 10**log_k
+        return np.array([-k * y[0], k * y[0]])
+
+    ode_rhs = create_ode_rhs(assemblies, reaction_kinds, reactions)
+
+    checker = OdeRhsEquivalenceChecker(ode_rhs, expected_ode_rhs)
+    # parameters: t, y, log_k_of_rxn_kinds
+    checker.check(0, np.array([1, 0]), np.array([0]))
+    checker.check(0, np.array([0.5, 0.5]), np.array([0]))
+    checker.check(0, np.array([1, 0]), np.array([2]))
+
+
 if __name__ == '__main__':
     pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request includes several changes to the `nasap/ode_creation` module to improve the handling of sequences and enhance code readability. The most important changes involve updating function parameters to use `Sequence` instead of `Iterable`, removing the `convert_reaction_to_use_index` function, and adding a new test case for string assembly IDs.

### Changes to function parameters:

* [`nasap/ode_creation/lib/particle_change.py`](diffhunk://#diff-41576f7c63af481d72f7d47927ed3e5a576a444aa2e44548c48757e098ff2027L1-R55): Updated parameters in `calc_particle_change`, `calc_consumed_count`, and `calc_produced_count` to use `Sequence` instead of `Iterable`.
* [`nasap/ode_creation/reactions_to_ode.py`](diffhunk://#diff-8ded9d74daa271badceb3f0a1eabc30c46dad8ed8c90844c8ad57dfe805fcaedL25-R25): Modified parameters in `create_ode_rhs` to use `Sequence` instead of `Iterable`.

### Code simplification:

* [`nasap/ode_creation/reaction_class.py`](diffhunk://#diff-39831b1fbf0f55660b36bc7e53f918e482235a2202513eb6e07f00682bd31ba4L50-L72): Removed the `convert_reaction_to_use_index` function as it is no longer needed.
* [`nasap/ode_creation/reactions_to_ode.py`](diffhunk://#diff-8ded9d74daa271badceb3f0a1eabc30c46dad8ed8c90844c8ad57dfe805fcaedL42-R71): Simplified the `create_ode_rhs` function by removing the conversion of reactions to use indices and directly using the provided sequences.

### Testing improvements:

* [`nasap/ode_creation/lib/tests/test_particle_change.py`](diffhunk://#diff-1bd4a1c3c4a2cdf3d19f020e22f8821c99db098d2cc7ac56c3856f54e983ea26L11-R82): Updated test cases to reflect changes in function parameters, replacing `number_of_assems` with `assems`.
* [`nasap/ode_creation/tests/test_reactions_to_ode.py`](diffhunk://#diff-bf1e673d4cc6b6eb25fa7cfa20af946cb023e74ec4c90919b12adb4fa75102ffR328-R351): Added a new test case `test_str_assem_ids` to verify the handling of string assembly IDs.