### PR TITLE
Fix reactions_to_ode to correctly handle duplicate reactions

### DIFF
--- a/nasap/ode_creation/reactions_to_ode.py
+++ b/nasap/ode_creation/reactions_to_ode.py
@@ -45,7 +45,6 @@ def create_ode_rhs(
     
     assem_to_index = {assem: i for i, assem in enumerate(assemblies)}
     rxn_kind_to_index = {kind: i for i, kind in enumerate(reaction_kinds)}
-    rxn_to_index = {reaction: i for i, reaction in enumerate(reactions)}
 
     # n: number of assemblies
     # m: number of reactions
@@ -56,13 +55,13 @@ def create_ode_rhs(
     
     # shape: (m, k), dtype: bool
     rxn_to_kind = np.full((num_of_rxns, num_of_rxn_kinds), False)
-    for reaction, i in rxn_to_index.items():
+    for i, reaction in enumerate(reactions):
         rxn_kind_index = rxn_kind_to_index[reaction.reaction_kind]
         rxn_to_kind[i, rxn_kind_index] = True
 
     # shape: (m,)
     coefficients = np.full(num_of_rxns, np.nan)
-    for reaction, i in rxn_to_index.items():
+    for i, reaction in enumerate(reactions):
         coefficients[i] = reaction.duplicate_count
     assert not np.isnan(coefficients).any()
     

--- a/nasap/ode_creation/tests/test_reactions_to_ode.py
+++ b/nasap/ode_creation/tests/test_reactions_to_ode.py
@@ -344,6 +344,31 @@ def test_str_assem_ids():
 
     checker = OdeRhsEquivalenceChecker(ode_rhs, expected_ode_rhs)
     # parameters: t, y, log_k_of_rxn_kinds
+
+
+def test_duplicate_reactions():
+    # A -> B  (k)
+    # A -> B  (k)  exactly the same as the previous reaction
+    assemblies = ['A', 'B']
+    reactions = [
+        Reaction(
+            reactants=['A'], products=['B'], reaction_kind='AtoB', 
+            duplicate_count=1),
+        Reaction(
+            reactants=['A'], products=['B'], reaction_kind='AtoB',
+            duplicate_count=1)
+        ]
+    reaction_kinds = ['AtoB']
+
+    def expected_ode_rhs(t, y, log_k_of_rxn_kinds):
+        log_k, = log_k_of_rxn_kinds
+        k = 10**log_k
+        k_tot = 2 * k
+        return np.array([-k_tot * y[0], k_tot * y[0]])
+    
+    ode_rhs = create_ode_rhs(assemblies, reaction_kinds, reactions)
+
+    checker = OdeRhsEquivalenceChecker(ode_rhs, expected_ode_rhs)
     checker.check(0, np.array([1, 0]), np.array([0]))
     checker.check(0, np.array([0.5, 0.5]), np.array([0]))
     checker.check(0, np.array([1, 0]), np.array([2]))


### PR DESCRIPTION
This pull request includes changes to the `nasap/ode_creation/reactions_to_ode.py` and `nasap/ode_creation/tests/test_reactions_to_ode.py` files to simplify the code and add a new test case for duplicate reactions. The most important changes include removing the `rxn_to_index` dictionary, updating the loop logic in `create_ode_rhs`, and adding a new test for duplicate reactions.

Code simplification:

* [`nasap/ode_creation/reactions_to_ode.py`](diffhunk://#diff-8ded9d74daa271badceb3f0a1eabc30c46dad8ed8c90844c8ad57dfe805fcaedL48): Removed the `rxn_to_index` dictionary and updated the loops to directly enumerate over `reactions`. [[1]](diffhunk://#diff-8ded9d74daa271badceb3f0a1eabc30c46dad8ed8c90844c8ad57dfe805fcaedL48) [[2]](diffhunk://#diff-8ded9d74daa271badceb3f0a1eabc30c46dad8ed8c90844c8ad57dfe805fcaedL59-R64)

New test case:

* [`nasap/ode_creation/tests/test_reactions_to_ode.py`](diffhunk://#diff-bf1e673d4cc6b6eb25fa7cfa20af946cb023e74ec4c90919b12adb4fa75102ffR347-R371): Added a new test case `test_duplicate_reactions` to verify the behavior when there are duplicate reactions.