### PR TITLE
Add CSV loading functionality for reactions and corresponding tests

### DIFF
--- a/nasap/ode_creation/__init__.py
+++ b/nasap/ode_creation/__init__.py
@@ -1,3 +1,4 @@
+from .csv_to_reactions import *
 from .lib import *
 from .reaction_class import *
 from .reactions_to_ode import *

--- a/nasap/ode_creation/csv_to_reactions.py
+++ b/nasap/ode_creation/csv_to_reactions.py
@@ -1,0 +1,132 @@
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Literal, overload
+
+import pandas as pd
+
+from .reaction_class import Reaction
+
+
+@overload
+def load_reactions_from_csv(
+        path: Path | str,
+        *,
+        reactant_cols: tuple[str, str] = (
+            'init_assem_id', 'entering_assem_id'),
+        product_cols: tuple[str, str] = (
+            'product_assem_id', 'leaving_assem_id'),
+        duplicate_count_col: str = 'duplicate_count',
+        reaction_kind_col: str = 'reaction_kind',
+        assem_dtype: Literal['int'] = 'int',
+        reaction_kind_dtype: Literal['int'] = 'int'
+        ) -> Sequence[Reaction[int, int]]:
+    ...
+@overload
+def load_reactions_from_csv(
+        path: Path | str,
+        *,
+        reactant_cols: tuple[str, str] = (
+            'init_assem_id', 'entering_assem_id'),
+        product_cols: tuple[str, str] = (
+            'product_assem_id', 'leaving_assem_id'),
+        duplicate_count_col: str = 'duplicate_count',
+        reaction_kind_col: str = 'reaction_kind',
+        assem_dtype: Literal['int'] = 'int',
+        reaction_kind_dtype: Literal['str'] = 'str'
+        ) -> Sequence[Reaction[int, str]]:
+    ...
+@overload
+def load_reactions_from_csv(
+        path: Path | str,
+        *,
+        reactant_cols: tuple[str, str] = (
+            'init_assem_id', 'entering_assem_id'),
+        product_cols: tuple[str, str] = (
+            'product_assem_id', 'leaving_assem_id'),
+        duplicate_count_col: str = 'duplicate_count',
+        reaction_kind_col: str = 'reaction_kind',
+        assem_dtype: Literal['str'] = 'str',
+        reaction_kind_dtype: Literal['int'] = 'int'
+        ) -> Sequence[Reaction[str, int]]:
+    ...
+@overload
+def load_reactions_from_csv(
+        path: Path | str,
+        *,
+        reactant_cols: tuple[str, str] = (
+            'init_assem_id', 'entering_assem_id'),
+        product_cols: tuple[str, str] = (
+            'product_assem_id', 'leaving_assem_id'),
+        duplicate_count_col: str = 'duplicate_count',
+        reaction_kind_col: str = 'reaction_kind',
+        assem_dtype: Literal['str'] = 'str',
+        reaction_kind_dtype: Literal['str'] = 'str'
+        ) -> Sequence[Reaction[str, str]]:
+    ...
+def load_reactions_from_csv(
+        path: Path | str,
+        *,
+        reactant_cols: tuple[str, str] = (
+            'init_assem_id', 'entering_assem_id'),
+        product_cols: tuple[str, str] = (
+            'product_assem_id', 'leaving_assem_id'),
+        duplicate_count_col: str = 'duplicate_count',
+        reaction_kind_col: str = 'reaction_kind',
+        assem_dtype: Literal['int', 'str'] = 'int',
+        reaction_kind_dtype: Literal['int', 'str'] = 'int'
+        ) -> Sequence[Reaction]:
+    assem_dtype_map = {'int': pd.Int64Dtype(), 'str': pd.StringDtype()}
+    reaction_kind_dtype_map = {'int': pd.Int64Dtype(), 'str': pd.StringDtype()}
+    assem_dtype_obj = assem_dtype_map[assem_dtype]
+    reaction_kind_dtype_obj = reaction_kind_dtype_map[reaction_kind_dtype]
+    df = pd.read_csv(
+        path,
+        usecols=[*reactant_cols, *product_cols, 
+                 duplicate_count_col, reaction_kind_col],
+        dtype={reactant_cols[0]: assem_dtype_obj, 
+               reactant_cols[1]: assem_dtype_obj,
+               product_cols[0]: assem_dtype_obj, 
+               product_cols[1]: assem_dtype_obj,
+               duplicate_count_col: pd.Int64Dtype(), 
+               reaction_kind_col: reaction_kind_dtype_obj
+               }
+        )
+    
+    assem_type = int if assem_dtype == 'int' else str
+    reaction_kind_type = int if reaction_kind_dtype == 'int' else str
+    
+    reactions: list[Reaction] = []
+
+    for row in df.itertuples(index=False):
+        reactants = []
+        if (reactant1 := getattr(row, reactant_cols[0])) is not pd.NA:
+            reactants.append(assem_type(reactant1))
+        if (reactant2 := getattr(row, reactant_cols[1])) is not pd.NA:
+            reactants.append(assem_type(reactant2))
+        if not reactants:
+            raise ValueError('At least one reactant must be provided.')
+        products = []
+        if (product1 := getattr(row, product_cols[0])) is not pd.NA:
+            products.append(assem_type(product1))
+        if (product2 := getattr(row, product_cols[1])) is not pd.NA:
+            products.append(assem_type(product2))
+        if not products:
+            raise ValueError('At least one product must be provided.')
+        if (dup_count := getattr(row, duplicate_count_col)) is pd.NA:
+            raise ValueError('Duplicate count must be provided.')
+        else:
+            dup_count = int(dup_count)
+        if (reaction_kind := getattr(row, reaction_kind_col)) is pd.NA:
+            raise ValueError('Reaction kind must be provided.')
+        else:
+            reaction_kind = reaction_kind_type(reaction_kind)
+        reactions.append(
+            Reaction(
+                reactants=reactants,
+                products=products,
+                reaction_kind=reaction_kind,
+                duplicate_count=dup_count,
+            )
+        )
+
+    return reactions

--- a/nasap/ode_creation/tests/test_csv_to_reactions.py
+++ b/nasap/ode_creation/tests/test_csv_to_reactions.py
@@ -1,0 +1,205 @@
+import pytest
+
+from nasap.ode_creation import Reaction, load_reactions_from_csv
+
+
+@pytest.fixture
+def default_header() -> str:
+    return (
+        'init_assem_id,entering_assem_id,'
+        'product_assem_id,leaving_assem_id,'
+        'duplicate_count,reaction_kind\n'
+    )
+
+
+# Helper function to test attributes of Reaction
+def assert_reaction_properties(
+        reaction: Reaction, 
+        reactants, products, reaction_kind, duplicate_count):
+    assert reaction.reactants == reactants
+    assert reaction.products == products
+    assert reaction.reaction_kind == reaction_kind
+    assert reaction.duplicate_count == duplicate_count
+
+
+def test(tmp_path, default_header):
+    csv = tmp_path / 'reactions.csv'
+    csv.write_text(
+        default_header +
+        '0,1,2,3,4,0\n'
+        '1,2,3,4,5,1\n'
+    )
+    reactions = load_reactions_from_csv(csv)
+
+    assert len(reactions) == 2
+    assert_reaction_properties(reactions[0], (0, 1), (2, 3), 0, 4)
+    assert_reaction_properties(reactions[1], (1, 2), (3, 4), 1, 5)
+
+# ==================================================
+# Test data with empty values
+
+# Data with no init_assem_id is allowed 
+# as long as entering_assem_id is provided.
+def test_no_init_assem(tmp_path, default_header):
+    csv = tmp_path / 'reactions.csv'
+    # init_assem_id is empty
+    csv.write_text(default_header + ',1,2,3,4,0\n')
+    reactions = load_reactions_from_csv(csv)
+
+    assert len(reactions) == 1
+    # init_assem_id is empty, so reactants should be [1]
+    assert_reaction_properties(reactions[0], (1,), (2, 3), 0, 4)
+
+
+def test_no_entering_assem(tmp_path, default_header):
+    csv = tmp_path / 'reactions.csv'
+    # entering_assem_id is empty
+    csv.write_text(default_header + '0,,2,3,4,0\n')
+    reactions = load_reactions_from_csv(csv)
+    
+    assert len(reactions) == 1
+    # entering_assem_id is empty, so reactants should be [0]
+    assert_reaction_properties(reactions[0], (0,), (2, 3), 0, 4)
+
+
+def test_no_init_or_entering_assem(tmp_path, default_header):
+    csv = tmp_path / 'reactions.csv'
+    # Both init_assem_id and entering_assem_id are empty
+    csv.write_text(default_header + ',,2,3,4,0\n')
+    # At least one reactant must be provided.
+    with pytest.raises(ValueError):
+        load_reactions_from_csv(csv)
+
+
+def test_no_product_assem(tmp_path, default_header):
+    csv = tmp_path / 'reactions.csv'
+    # product_assem_id is empty
+    csv.write_text(default_header + '0,1,,3,4,0\n')
+    reactions = load_reactions_from_csv(csv)
+    
+    assert len(reactions) == 1
+    # product_assem_id is empty, so products should be [3]
+    assert_reaction_properties(reactions[0], (0, 1), (3,), 0, 4)
+
+
+def test_no_leaving_assem(tmp_path, default_header):
+    csv = tmp_path / 'reactions.csv'
+    # leaving_assem_id is empty
+    csv.write_text(default_header + '0,1,2,,4,0\n')
+    reactions = load_reactions_from_csv(csv)
+    
+    assert len(reactions) == 1
+    # leaving_assem_id is empty, so products should be [2]
+    assert_reaction_properties(reactions[0], (0, 1), (2,), 0, 4)
+
+
+def test_no_product_or_leaving_assem(tmp_path, default_header):
+    csv = tmp_path / 'reactions.csv'
+    # Both product_assem_id and leaving_assem_id are empty
+    csv.write_text(default_header + '0,1,,,4,0\n')
+    # At least one product must be provided.
+    with pytest.raises(ValueError):
+        load_reactions_from_csv(csv)
+
+
+def test_no_duplicate_count(tmp_path, default_header):
+    csv = tmp_path / 'reactions.csv'
+    # duplicate_count is empty
+    csv.write_text(default_header + '0,1,2,3,,0\n')
+    # Duplicate count must be provided.
+    with pytest.raises(ValueError):
+        load_reactions_from_csv(csv)
+
+
+def test_no_reaction_kind(tmp_path, default_header):
+    csv = tmp_path / 'reactions.csv'
+    # reaction_kind is empty
+    csv.write_text(default_header + '0,1,2,3,4,\n')
+    # Reaction kind must be provided.
+    with pytest.raises(ValueError):
+        load_reactions_from_csv(csv)
+
+
+# ==================================================
+# Test custom column names
+
+def test_custom_column_names(tmp_path):
+    csv = tmp_path / 'reactions.csv'
+    csv.write_text(
+        'init,enter,product,leave,dup,kind\n'
+        '0,1,2,3,4,0\n'
+    )
+    reactions = load_reactions_from_csv(
+        csv,
+        reactant_cols=('init', 'enter'),
+        product_cols=('product', 'leave'),
+        duplicate_count_col='dup',
+        reaction_kind_col='kind',
+    )
+    
+    assert len(reactions) == 1
+    assert_reaction_properties(reactions[0], (0, 1), (2, 3), 0, 4)
+
+
+# ==================================================
+# Test data types
+
+def test_int_assem_ids(tmp_path, default_header):
+    csv = tmp_path / 'reactions.csv'
+    csv.write_text(
+        default_header +
+        '0,1,2,3,4,0\n'
+        '1,2,3,4,5,1\n'
+    )
+    reactions = load_reactions_from_csv(csv, assem_dtype='int')
+
+    assert len(reactions) == 2
+    assert_reaction_properties(reactions[0], (0, 1), (2, 3), 0, 4)
+    assert_reaction_properties(reactions[1], (1, 2), (3, 4), 1, 5)
+
+
+def test_str_assem_ids(tmp_path, default_header):
+    csv = tmp_path / 'reactions.csv'
+    csv.write_text(
+        default_header +
+        '0,1,2,3,4,0\n'
+        '1,2,3,4,5,1\n'
+    )
+    reactions = load_reactions_from_csv(
+        csv, assem_dtype='str', reaction_kind_dtype='str')
+
+    assert len(reactions) == 2
+    assert_reaction_properties(reactions[0], ('0', '1'), ('2', '3'), '0', 4)
+    assert_reaction_properties(reactions[1], ('1', '2'), ('3', '4'), '1', 5)
+
+
+def test_int_reaction_kind(tmp_path, default_header):
+    csv = tmp_path / 'reactions.csv'
+    csv.write_text(
+        default_header +
+        '0,1,2,3,4,0\n'
+        '1,2,3,4,5,1\n'
+    )
+    reactions = load_reactions_from_csv(csv, reaction_kind_dtype='int')
+
+    assert len(reactions) == 2
+    assert_reaction_properties(reactions[0], (0, 1), (2, 3), 0, 4)
+    assert_reaction_properties(reactions[1], (1, 2), (3, 4), 1, 5)
+
+
+def test_str_reaction_kind(tmp_path, default_header):
+    csv = tmp_path / 'reactions.csv'
+    csv.write_text(
+        default_header +
+        '0,1,2,3,4,0\n'
+        '1,2,3,4,5,1\n'
+    )
+    reactions = load_reactions_from_csv(csv, reaction_kind_dtype='str')
+
+    assert len(reactions) == 2
+    assert_reaction_properties(reactions[0], (0, 1), (2, 3), '0', 4)
+    assert_reaction_properties(reactions[1], (1, 2), (3, 4), '1', 5)
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces significant changes to the `nasap/ode_creation` module, primarily focusing on the addition of a new function to load reactions from a CSV file and comprehensive tests for this functionality. The changes include importing necessary modules, defining the `load_reactions_from_csv` function with multiple overloads, and adding tests to ensure the function works correctly under various scenarios.

### New functionality:

* [`nasap/ode_creation/csv_to_reactions.py`](diffhunk://#diff-d16d98eb07ca91f7e5eec4ea6b1115f3e698a320b3b19e76ae37f5f20482a46eR1-R132): Added the `load_reactions_from_csv` function to load reactions from a CSV file with support for different data types and custom column names.

### Testing:

* [`nasap/ode_creation/tests/test_csv_to_reactions.py`](diffhunk://#diff-61ff35ccb5edd39dbfb735f42c602e1838083afc2301fa5d132e240c9de5870eR1-R205): Added tests for the `load_reactions_from_csv` function, covering various scenarios such as missing values, custom column names, and different data types.

### Import adjustments:

* [`nasap/ode_creation/__init__.py`](diffhunk://#diff-83fbf37030bd6524ad6e071c8b509d516525c7742cc93a4bc04919b29e3f1e8dR1): Updated imports to include the new `csv_to_reactions` module.