### PR TITLE
Add simulation_with_addition functionality and corresponding tests

### DIFF
--- a/nasap/simulation/__init__.py
+++ b/nasap/simulation/__init__.py
@@ -1,2 +1,3 @@
 from .gillespie import *
+from .simlation_with_addition import *
 from .simulating_func import *

--- a/nasap/simulation/simlation_with_addition.py
+++ b/nasap/simulation/simlation_with_addition.py
@@ -1,0 +1,109 @@
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any, Concatenate
+
+import numpy as np
+import numpy.typing as npt
+from scipy.integrate import solve_ivp
+
+
+def simulate_with_addition(
+        ode_rhs: Callable[
+            Concatenate[float, npt.NDArray, ...], npt.NDArray],
+        t: npt.NDArray,
+        t0: float, y0: npt.NDArray, 
+        ode_rhs_args: Iterable | None = None,
+        addition: Mapping[Any, npt.NDArray] | None = None,
+        *,
+        method: str = 'RK45', rtol: float = 1e-3, atol: float = 1e-6,
+        ) -> npt.NDArray:
+    """Simulate an ODE with addition."""
+    _validate_addition(t, t0, y0, addition)
+    if ode_rhs_args is None:
+        ode_rhs_args = ()
+    ode_rhs_args = tuple(ode_rhs_args)
+    
+    def solve_ivp_wrapper(
+            t0: float, y0: npt.NDArray, t_eval: npt.NDArray
+            ) -> npt.NDArray:
+        sol = solve_ivp(
+            ode_rhs, [t0, t_eval[-1]], y0, t_eval=t_eval, 
+            args=ode_rhs_args, method=method, rtol=rtol, atol=atol)
+        return sol.y.T
+
+    if addition is None or len(addition) == 0:
+        return solve_ivp_wrapper(t0, y0, t)
+
+    if t0 in addition:
+        raise ValueError(
+            f't0 ({t0}) cannot be in the addition times. Use y0 instead.')
+    if addition.keys() & set(t):
+        raise ValueError(
+            f'Addition times {addition.keys()} cannot be in t.'
+            f'Use a time point slightly greater than or less than '
+            f'the addition times.')
+
+    # Treat y0 as an addition at t0.
+    addition = dict(addition)
+    addition[t0] = y0
+    
+    # y_at_cur_t_add contains y just before the next addition.
+    # Since y0 will be added at t0, y_at_cur_t_add should be initialized
+    # with zeros.
+    y_just_before_cur_add = np.zeros_like(y0)
+
+    # Sort the addition times.
+    addition_times = sorted(addition.keys())
+
+    y = np.empty((0, *y0.shape))
+
+    for i, t_add in enumerate(addition_times):
+        change = addition[t_add]
+        
+        # Perform the addition.
+        y_just_after_cur_add = y_just_before_cur_add + change
+        
+        # If the last iteration.
+        if i == len(addition_times) - 1:
+            cur_t_eval = t[t >= t_add]
+            cur_y = solve_ivp_wrapper(t_add, y_just_after_cur_add, cur_t_eval)
+            y = np.concatenate([y, cur_y])
+            break
+        
+        next_t_add = addition_times[i + 1]
+        cur_t_eval = t[(t >= t_add) & (t < next_t_add)]
+
+        # y at next_t_add should be evaluated,
+        # which will be y_just_before_cur_add for the next addition.
+        cur_t_eval = np.concatenate([cur_t_eval, [next_t_add]])
+        
+        cur_y = solve_ivp_wrapper(t_add, y_just_after_cur_add, cur_t_eval)
+        y_just_before_cur_add = cur_y[-1]  # Update for the next addition.
+
+        # Remove y at next_t_add if it is not originally in t.
+        cur_y = cur_y[:-1]
+        
+        y = np.concatenate([y, cur_y])
+
+    return y
+
+
+def _validate_addition(
+        t: npt.NDArray, t0: float, y0: npt.NDArray,
+        addition: Mapping[float, npt.NDArray] | None,
+        ):
+    if addition is None:
+        return
+    
+    if len(addition) == 0:
+        return
+    
+    for t_add, change in addition.items():
+        if t_add < t0:
+            raise ValueError(f'time {t_add} is less than t0 ({t0})')
+        if t_add > t[-1]:
+            raise ValueError(
+                f'time {t_add} is greater than t_seq[-1] ({t[-1]})')
+        if change.shape != y0.shape:
+            raise ValueError(
+                f'change shape {change.shape} is different from y0 shape '
+                f'{y0.shape}')

--- a/nasap/simulation/tests/test_simulation_with_addition.py
+++ b/nasap/simulation/tests/test_simulation_with_addition.py
@@ -1,0 +1,102 @@
+import numpy as np
+import numpy.typing as npt
+import pytest
+from scipy.integrate import solve_ivp
+
+from nasap.simulation import simulate_with_addition
+
+
+# A -> B
+def ode_rhs(
+        t: float, y: npt.NDArray, log_k_array: npt.NDArray
+        ) -> npt.NDArray:
+    k_array = 10.0 ** log_k_array
+    k = k_array[0]
+    a, b = y
+    da_dt = -k * a
+    db_dt = k * a
+    return np.array([da_dt, db_dt])
+
+@pytest.fixture
+def t() -> npt.NDArray:
+    return np.array([5, 10, 15, 20, 25, 30, 60, 120, 180, 300])
+
+@pytest.fixture
+def t0() -> float:
+    return 0
+
+@pytest.fixture
+def y0() -> npt.NDArray:
+    return np.array([1, 0]) * 1e-3
+
+@pytest.fixture
+def log_k_array() -> npt.NDArray:
+    return np.array([-2])
+
+
+def test_without_addition(t, t0, y0, log_k_array):
+    sol = solve_ivp(
+        ode_rhs, [t0, t[-1]], y0, t_eval=t, args=(log_k_array,),
+        method='LSODA')
+    expected_y = sol.y.T
+
+    y = simulate_with_addition(
+        ode_rhs, t, t0, y0, ode_rhs_args=(log_k_array,), addition=None,
+        method='LSODA')
+    np.testing.assert_allclose(y, expected_y, rtol=1e-3)
+
+
+def test_addition(y0, log_k_array):
+    t = np.array([5, 10, 15, 20, 25, 30, 60, 120, 180, 300])
+    addition = {90.: np.array([1, 0]) * 1e-3}
+    first_t = np.array([5, 10, 15, 20, 25, 30, 60])
+    second_t = np.array([120, 180, 300])
+    
+    first_y0 = np.array([1, 0]) * 1e-3
+    first_sol = solve_ivp(
+        ode_rhs, [0, first_t[-1]], first_y0, t_eval=first_t, 
+        args=(log_k_array,), method='LSODA')
+    first_y = first_sol.y.T
+
+    sol_for_y_at_90 = solve_ivp(
+        ode_rhs, [0, 90], first_y0, t_eval=np.array([90]),
+        args=(log_k_array,), method='LSODA')
+    y_just_before_addition = sol_for_y_at_90.y.T[0]
+
+    y_just_after_addition = y_just_before_addition + addition[90]
+    second_sol = solve_ivp(
+        ode_rhs, [90, second_t[-1]], y_just_after_addition, 
+        t_eval=second_t, args=(log_k_array,), method='LSODA')
+    second_y = second_sol.y.T
+
+    expected_y = np.vstack([first_y, second_y])
+
+    y = simulate_with_addition(
+        ode_rhs, t, 0, y0, ode_rhs_args=(log_k_array,), addition=addition,
+        method='LSODA')
+    
+    assert len(y) == len(expected_y)
+    np.testing.assert_allclose(y, expected_y, atol=1e-6, rtol=1e-3)
+
+
+def test_addition_at_t0(y0, log_k_array):
+    t0 = 0
+    t = np.array([5, 10])
+    addition = {t0: np.array([1, 0]) * 1e-3}  # Addition at t0
+    with pytest.raises(ValueError):
+        simulate_with_addition(
+            ode_rhs, t, t0, y0, ode_rhs_args=(log_k_array,), addition=addition,
+            method='LSODA')
+
+
+def test_addition_at_time_in_t(t0, y0, log_k_array):
+    t = np.array([5, 10])
+    addition = {10: np.array([1, 0]) * 1e-3}
+    with pytest.raises(ValueError):
+        simulate_with_addition(
+            ode_rhs, t, t0, y0, ode_rhs_args=(log_k_array,), addition=addition,
+            method='LSODA')
+
+
+if __name__ == '__main__':
+    pytest.main(['-vv', __file__])


### PR DESCRIPTION
This pull request introduces a new feature to simulate an chemical reaction during which some species are added and includes the necessary tests to ensure its functionality. The most important changes include the addition of a new simulation function, validation logic, and comprehensive tests.

### New Simulation Feature:
* [`nasap/simulation/__init__.py`](diffhunk://#diff-53458123f84f68b4a0665a314b7f3b7480f183f0e0dfc04b261b13f2f99b079aR2): Added import for the new simulation module.
* [`nasap/simulation/simlation_with_addition.py`](diffhunk://#diff-6bdad95386c02f719d103a20c24f8284dc2eac34e6fd4c8a089638be72dbc2faR1-R109): Added the `simulate_with_addition` function, which allows simulating an chemical reaction during which some species are added at specified times. This includes the core logic and validation functions.

### Testing:
* [`nasap/simulation/tests/test_simulation_with_addition.py`](diffhunk://#diff-ddabf56ac1d02f600b9efddcdd8f4ecc4abc7704b37e24f9317a3135c797c5c7R1-R102): Added tests to verify the functionality of the `simulate_with_addition` function. This includes tests for scenarios without addition, with addition, and edge cases where additions occur at invalid times.