### PR TITLE
Add convert_id_value_dict_to_array function and corresponding tests

### DIFF
--- a/nasap/simulation/utils/__init__.py
+++ b/nasap/simulation/utils/__init__.py
@@ -1,1 +1,2 @@
 from .conc_to_ratio import *
+from .id_value_dict_to_array import *

--- a/nasap/simulation/utils/id_value_dict_to_array.py
+++ b/nasap/simulation/utils/id_value_dict_to_array.py
@@ -1,0 +1,20 @@
+from collections.abc import Mapping, Sequence
+from typing import TypeVar
+
+import numpy as np
+import numpy.typing as npt
+
+_T = TypeVar('_T')
+
+
+def convert_id_value_dict_to_array(
+        ids: Sequence[_T],
+        id_to_value: Mapping[_T, float],
+        *,
+        default: float | np.float64 = np.nan,
+        ) -> npt.NDArray:
+    id_to_index = {id_: i for i, id_ in enumerate(ids)}
+    array = np.full(len(ids), default)
+    for id_, value in id_to_value.items():
+        array[id_to_index[id_]] = value
+    return array

--- a/nasap/simulation/utils/tests/test_id_value_dict_to_array.py
+++ b/nasap/simulation/utils/tests/test_id_value_dict_to_array.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+from nasap.simulation.utils import convert_id_value_dict_to_array
+
+
+def test():
+    ids = ['a', 'b', 'c']
+    id_to_value = {'a': 1, 'b': 2}
+    expected = [1, 2, np.nan]
+    
+    array = convert_id_value_dict_to_array(ids, id_to_value)
+    
+    assert isinstance(array, np.ndarray)
+    np.testing.assert_allclose(array, expected)
+
+
+def test_default():
+    ids = ['a', 'b', 'c']
+    id_to_value = {'a': 1, 'b': 2}
+    expected = [1, 2, 0]
+    
+    array = convert_id_value_dict_to_array(ids, id_to_value, default=0)
+    
+    assert isinstance(array, np.ndarray)
+    np.testing.assert_allclose(array, expected)
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new utility function to convert a dictionary of ID-value pairs into a NumPy array, along with corresponding tests. The main changes include the addition of the new function, its import in the utility module, and the creation of test cases to ensure its correctness.

New utility function and tests:

* [`nasap/simulation/utils/id_value_dict_to_array.py`](diffhunk://#diff-3e20eface54bab1ce474392322a9ce0553dcf140fc872bb76b28e79a8d35e895R1-R20): Added the `convert_id_value_dict_to_array` function to convert a dictionary of ID-value pairs into a NumPy array.
* [`nasap/simulation/utils/__init__.py`](diffhunk://#diff-9b2d46a65a04a4396e1afd5f5f995376b7e71b4b827dcbe087d9fb4400949a9dR2): Imported the new `convert_id_value_dict_to_array` function.
* [`nasap/simulation/utils/tests/test_id_value_dict_to_array.py`](diffhunk://#diff-8faf53b65e3455f23f2323beeb5c8030afdb9c791d79835c05a23105af35cfd2R1-R30): Created tests for the `convert_id_value_dict_to_array` function to verify its behavior with default and custom default values.