### PR TITLE
Rename id_value_dict_to_array to id_value_mapping_to_array

### DIFF
--- a/nasap/simulation/utils/__init__.py
+++ b/nasap/simulation/utils/__init__.py
@@ -1,2 +1,2 @@
 from .conc_to_ratio import *
-from .id_value_dict_to_array import *
+from .id_value_mapping_to_array import *

--- a/nasap/simulation/utils/id_value_mapping_to_array.py
+++ b/nasap/simulation/utils/id_value_mapping_to_array.py
@@ -7,7 +7,7 @@ import numpy.typing as npt
 _T = TypeVar('_T')
 
 
-def convert_id_value_dict_to_array(
+def convert_id_value_mapping_to_array(
         ids: Sequence[_T],
         id_to_value: Mapping[_T, float],
         *,

--- a/nasap/simulation/utils/tests/test_id_value_mapping_to_array.py
+++ b/nasap/simulation/utils/tests/test_id_value_mapping_to_array.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from nasap.simulation.utils import convert_id_value_dict_to_array
+from nasap.simulation.utils import convert_id_value_mapping_to_array
 
 
 def test():
@@ -9,7 +9,7 @@ def test():
     id_to_value = {'a': 1, 'b': 2}
     expected = [1, 2, np.nan]
     
-    array = convert_id_value_dict_to_array(ids, id_to_value)
+    array = convert_id_value_mapping_to_array(ids, id_to_value)
     
     assert isinstance(array, np.ndarray)
     np.testing.assert_allclose(array, expected)
@@ -20,7 +20,7 @@ def test_default():
     id_to_value = {'a': 1, 'b': 2}
     expected = [1, 2, 0]
     
-    array = convert_id_value_dict_to_array(ids, id_to_value, default=0)
+    array = convert_id_value_mapping_to_array(ids, id_to_value, default=0)
     
     assert isinstance(array, np.ndarray)
     np.testing.assert_allclose(array, expected)


### PR DESCRIPTION
This pull request includes changes to rename a function and its corresponding test files in the `nasap/simulation/utils` module. The changes ensure consistency in naming conventions and improve code readability.

Function and test renaming:

* [`nasap/simulation/utils/__init__.py`](diffhunk://#diff-9b2d46a65a04a4396e1afd5f5f995376b7e71b4b827dcbe087d9fb4400949a9dL2-R2): Updated import statement to reflect the new function name `id_value_mapping_to_array` instead of `id_value_dict_to_array`.
* [`nasap/simulation/utils/id_value_mapping_to_array.py`](diffhunk://#diff-8e844060bb01d499c6e322b9a8c4b612ed9b82ded1a29501183837870f955b92L10-R10): Renamed file from `id_value_dict_to_array.py` and updated the function name to `convert_id_value_mapping_to_array`.
* [`nasap/simulation/utils/tests/test_id_value_mapping_to_array.py`](diffhunk://#diff-052825aee513b186629c9db108731a9dcbf86f26983b03aa3f5599f87e8b4739L4-R12): Renamed test file from `test_id_value_dict_to_array.py` and updated the test cases to use the new function name `convert_id_value_mapping_to_array`. [[1]](diffhunk://#diff-052825aee513b186629c9db108731a9dcbf86f26983b03aa3f5599f87e8b4739L4-R12) [[2]](diffhunk://#diff-052825aee513b186629c9db108731a9dcbf86f26983b03aa3f5599f87e8b4739L23-R23)