### PR TITLE
Add alias_id module with functions for alias ID handling

### DIFF
--- a/nasap/simulation/utils/__init__.py
+++ b/nasap/simulation/utils/__init__.py
@@ -1,2 +1,3 @@
+from .alias_id import *
 from .conc_to_ratio import *
 from .id_value_mapping_to_array import *

--- a/nasap/simulation/utils/alias_id.py
+++ b/nasap/simulation/utils/alias_id.py
@@ -1,0 +1,54 @@
+"""This module provides functions for working with alias IDs."""
+
+from collections.abc import Hashable, Iterable, Mapping, Sequence
+from typing import TypeVar
+
+import numpy as np
+import numpy.typing as npt
+
+from .id_value_mapping_to_array import convert_id_value_mapping_to_array
+
+_T = TypeVar('_T', bound=Hashable)
+_S = TypeVar('_S', bound=Hashable)
+_U = TypeVar('_U', int, float)
+
+
+def convert_alias_mapping_to_array(
+        ids: Sequence[_T],
+        alias_to_id: Mapping[_S, _T],
+        alias_to_value: Mapping[_S, float],
+        *,
+        default: float | np.float64 = np.nan,
+        ) -> npt.NDArray:
+    _validate_alias_assem_ids(alias_to_id, ids)
+    id_to_value = {
+        alias_to_id[alias]: value
+        for alias, value in alias_to_value.items()}
+    return convert_id_value_mapping_to_array(ids, id_to_value, default=default)
+
+
+def get_extracted_y_by_alias(
+        y: npt.NDArray,
+        alias_assem_ids_to_extract: Iterable[_S],
+        assem_ids: Sequence[_T],
+        alias_to_assem_id: Mapping[_S, _T],
+        ) -> npt.NDArray:
+    id_to_index = {id_: i for i, id_ in enumerate(assem_ids)}
+    y_extracted = np.empty((y.shape[0], len(list(alias_assem_ids_to_extract))))
+    for i, alias in enumerate(alias_assem_ids_to_extract):
+        assem_id = alias_to_assem_id[alias]
+        y_extracted[:, i] = y[:, id_to_index[assem_id]]
+    return y_extracted
+
+
+def _validate_alias_assem_ids(
+        alias_to_assem_id: Mapping[_S, _T],
+        assem_ids: Iterable[_T],
+        ) -> None:
+    assem_ids = set(assem_ids)
+    for alias, assem_id in alias_to_assem_id.items():
+        if assem_id not in assem_ids:
+            raise ValueError(
+                f'Invalid assem_id "{assem_id}" for alias "{alias}"')
+        if alias in assem_ids:
+            raise ValueError(f'Alias "{alias}" is already an assem_id')

--- a/nasap/simulation/utils/tests/test_alias_id.py
+++ b/nasap/simulation/utils/tests/test_alias_id.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+from nasap.simulation.utils import (convert_alias_mapping_to_array,
+                                    get_extracted_y_by_alias)
+
+
+def test_convert_alias_mapping_to_array():
+    ids = ['A', 'B', 'C']
+    alias_to_id = {'a': 'A', 'b': 'B'}  # C has no alias
+    alias_to_value = {'a': 1.0, 'b': 2.0}
+    expected = np.array([1.0, 2.0, np.nan])
+    result = convert_alias_mapping_to_array(
+        ids, alias_to_id, alias_to_value)
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_convert_alias_mapping_to_array_with_default():
+    ids = ['A', 'B', 'C']
+    alias_to_id = {'a': 'A', 'b': 'B'}  # C has no alias
+    alias_to_value = {'a': 1.0, 'b': 2.0}
+    expected = np.array([1.0, 2.0, 0.0])
+    result = convert_alias_mapping_to_array(
+        ids, alias_to_id, alias_to_value, default=0.0)
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_get_extracted_y_by_alias():
+    # A -> B + 2C
+    y = np.array([[1, 0, 0], [0.5, 1, 2]])
+    alias_assem_ids_to_extract = ['a', 'b']
+    assem_ids = ['A', 'B', 'C']
+    alias_to_assem_id = {'a': 'A', 'b': 'B'}
+    expected = np.array([[1, 0], [0.5, 1]])
+    result = get_extracted_y_by_alias(
+        y, alias_assem_ids_to_extract, assem_ids, alias_to_assem_id)
+    np.testing.assert_array_equal(result, expected)
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces new functionality for working with alias IDs in the `nasap/simulation/utils` module. The main changes include the addition of a new module `alias_id.py`, updates to the `__init__.py` to include the new module, and the creation of tests for the new functions.

New functionality:

* [`nasap/simulation/utils/alias_id.py`](diffhunk://#diff-50c8867ab9479ec0a555262aec955d9b652a65492ac2161148253706a7bfb4a8R1-R54): Added functions `convert_alias_mapping_to_array`, `get_extracted_y_by_alias`, and `_validate_alias_assem_ids` to handle alias ID mappings and data extraction.

Module updates:

* [`nasap/simulation/utils/__init__.py`](diffhunk://#diff-9b2d46a65a04a4396e1afd5f5f995376b7e71b4b827dcbe087d9fb4400949a9dR1): Included the new `alias_id` module to be part of the utils package.

Testing:

* [`nasap/simulation/utils/tests/test_alias_id.py`](diffhunk://#diff-c36b2b4a4410fb4de727b956d60821680ff8ae5f6761c516386963208b6870d2R1-R41): Added tests for the new functions in `alias_id.py` to ensure they work as expected.