### PR TITLE
Change reactions parameter type from Sequence to Iterable

### DIFF
--- a/nasap/ode_creation/reactions_to_ode.py
+++ b/nasap/ode_creation/reactions_to_ode.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import Protocol, TypeVar
 
 import numpy as np
@@ -22,7 +22,7 @@ class OdeRhs(Protocol):
 def create_ode_rhs(
         assemblies: Sequence[_T_co], 
         reaction_kinds: Sequence[_S_co],
-        reactions: Sequence[Reaction[_T_co, _S_co]],
+        reactions: Iterable[Reaction[_T_co, _S_co]],
         ) -> OdeRhs:
     """Create a function that calculates the right-hand side of the ODE.
 


### PR DESCRIPTION
This pull request includes changes to the `nasap/ode_creation/reactions_to_ode.py` file to improve the flexibility of the `create_ode_rhs` function by allowing it to accept any iterable collection for the `reactions` parameter.

Changes to improve flexibility:

* [`nasap/ode_creation/reactions_to_ode.py`](diffhunk://#diff-8ded9d74daa271badceb3f0a1eabc30c46dad8ed8c90844c8ad57dfe805fcaedL1-R1): Imported `Iterable` from `collections.abc` to support the use of any iterable collection.
* [`nasap/ode_creation/reactions_to_ode.py`](diffhunk://#diff-8ded9d74daa271badceb3f0a1eabc30c46dad8ed8c90844c8ad57dfe805fcaedL25-R25): Modified the `create_ode_rhs` function to accept `Iterable` instead of `Sequence` for the `reactions` parameter, enhancing its flexibility.