### PR TITLE
Add AliasAddition class with to_addition method

### DIFF
--- a/nasap/simulation/__init__.py
+++ b/nasap/simulation/__init__.py
@@ -1,3 +1,4 @@
+from .addition import *
 from .gillespie import *
 from .simulating_func import *
 from .simulation_with_addition import *

--- a/nasap/simulation/addition.py
+++ b/nasap/simulation/addition.py
@@ -1,0 +1,53 @@
+from collections.abc import Hashable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+import numpy as np
+import numpy.typing as npt
+
+_T = TypeVar('_T', bound=Hashable)
+_S = TypeVar('_S', bound=Hashable)
+
+
+@dataclass
+class Addition:
+    time: float
+    solute_change: npt.NDArray
+    volume_change: float
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Addition):
+            return NotImplemented
+        return (
+            self.time == other.time
+            and np.array_equal(self.solute_change, other.solute_change)
+            and self.volume_change == other.volume_change)
+
+
+@dataclass
+class AliasAddition(Generic[_S]):
+    time: float
+    solute_change: Mapping[_S, float]
+    volume_change: float
+
+    def to_addition(
+            self, alias_to_id: Mapping[_S, _T], ids: Sequence[_T],
+            *,
+            default_solute_change: float | np.float64 = 0.0,
+            ) -> Addition:
+        ids = list(ids)
+        if len(ids) != len(set(ids)):
+            raise ValueError('ids should be unique')
+        for alias in self.solute_change:
+            if alias not in alias_to_id:
+                raise ValueError(f'{alias} not in alias_to_id')
+        for alias, id_ in alias_to_id.items():
+            if id_ not in ids:
+                raise ValueError(f'{id_} not in ids')
+        solute_change_array = np.full(len(ids), default_solute_change)
+        id_to_index = {id_: i for i, id_ in enumerate(ids)}
+        for alias, change in self.solute_change.items():
+            solute_change_array[id_to_index[alias_to_id[alias]]] = change
+        return Addition(
+            time=self.time, solute_change=solute_change_array,
+            volume_change=self.volume_change)

--- a/nasap/simulation/simulation_with_addition.py
+++ b/nasap/simulation/simulation_with_addition.py
@@ -1,25 +1,13 @@
 import warnings
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import Any, Concatenate
+from typing import Concatenate
 
 import numpy as np
 import numpy.typing as npt
 from scipy.integrate import solve_ivp
 
-
-@dataclass
-class Addition:
-    time: float
-    solute_change: npt.NDArray
-    volume_change: float
-
-
-@dataclass
-class AliasAddition:
-    time: float
-    solute_change: Mapping[str, float]
-    volume_change: float
+from nasap.simulation.addition import Addition
 
 
 @dataclass

--- a/nasap/simulation/tests/test_addition.py
+++ b/nasap/simulation/tests/test_addition.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+
+from nasap.simulation import Addition, AliasAddition
+
+
+def test_alias_addition_to_addition():
+    ids = ['A', 'B', 'C']
+    alias_to_id = {'a': 'A', 'b': 'B'}  # No alias for 'C'
+    alias_addition = AliasAddition(
+        time=1, solute_change={'a': 1, 'b': 2}, volume_change=3)
+    
+    expected = Addition(
+        time=1, solute_change=np.array([1, 2, 0]), volume_change=3)
+    
+    addition = alias_addition.to_addition(alias_to_id, ids)
+
+    assert addition == expected
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])

--- a/nasap/simulation/tests/test_simulation_with_addition.py
+++ b/nasap/simulation/tests/test_simulation_with_addition.py
@@ -4,8 +4,8 @@ import numpy.typing as npt
 import pytest
 from scipy.integrate import solve_ivp
 
-from nasap.simulation import (Addition, SimulationResult,
-                              simulate_solute_with_addition)
+from nasap.simulation import SimulationResult, simulate_solute_with_addition
+from nasap.simulation.addition import Addition
 
 
 # A -> B


### PR DESCRIPTION
This pull request introduces a new `Addition` class and its related functionalities, along with relevant tests. The changes primarily focus on the `nasap/simulation` module.

Key changes include:

### New Class and Functionality

* Added `Addition` and `AliasAddition` classes in `nasap/simulation/addition.py` to represent solute and volume changes over time, with methods to convert `AliasAddition` to `Addition`.

### Refactoring

* Removed the old `Addition` and `AliasAddition` classes from `nasap/simulation/simulation_with_addition.py` and imported the new `Addition` class from `nasap/simulation/addition.py`.

### Testing

* Added tests for the `AliasAddition` to `Addition` conversion in `nasap/simulation/tests/test_addition.py`.
* Updated imports in `nasap/simulation/tests/test_simulation_with_addition.py` to use the new `Addition` class from `nasap/simulation/addition.py`.

### Initialization

* Updated `nasap/simulation/__init__.py` to include the new `addition` module.