### PR TITLE
Ensure default value is converted to float in np.full

### DIFF
--- a/nasap/simulation/utils/id_value_mapping_to_array.py
+++ b/nasap/simulation/utils/id_value_mapping_to_array.py
@@ -14,7 +14,7 @@ def convert_id_value_mapping_to_array(
         default: float | np.float64 = np.nan,
         ) -> npt.NDArray:
     id_to_index = {id_: i for i, id_ in enumerate(ids)}
-    array = np.full(len(ids), default)
+    array = np.full(len(ids), float(default))
     for id_, value in id_to_value.items():
         array[id_to_index[id_]] = value
     return array

--- a/nasap/simulation/utils/tests/test_id_value_mapping_to_array.py
+++ b/nasap/simulation/utils/tests/test_id_value_mapping_to_array.py
@@ -26,5 +26,18 @@ def test_default():
     np.testing.assert_allclose(array, expected)
 
 
+def test_int_default():
+    # Should be converted to np.float64
+    ids = ['a', 'b', 'c']
+    id_to_value = {'a': 1, 'b': 2}
+    expected = [1, 2, 0]
+    
+    array = convert_id_value_mapping_to_array(ids, id_to_value, default=0)
+
+    assert array.dtype == np.float64
+    assert isinstance(array, np.ndarray)
+    np.testing.assert_allclose(array, expected)
+
+
 if __name__ == '__main__':
     pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request includes changes to the `convert_id_value_mapping_to_array` function and its corresponding tests to ensure proper handling of default values. The most important changes include modifying the function to correctly handle default values and adding a new test case to verify this behavior.

Function improvements:

* [`nasap/simulation/utils/id_value_mapping_to_array.py`](diffhunk://#diff-8e844060bb01d499c6e322b9a8c4b612ed9b82ded1a29501183837870f955b92L17-R17): Modified the `convert_id_value_mapping_to_array` function to ensure the `default` value is correctly converted to a float.

Testing enhancements:

* [`nasap/simulation/utils/tests/test_id_value_mapping_to_array.py`](diffhunk://#diff-052825aee513b186629c9db108731a9dcbf86f26983b03aa3f5599f87e8b4739R29-R41): Added a new test case `test_int_default` to verify that the `default` value is correctly converted to `np.float64` and the function works as expected.