### PR TITLE
ResolvedReaction クラスは計算済みの速度定数のみを持つようにする。不要なフィールドは削除

### DIFF
--- a/src/nasap_fit_py/simulation/rate_constant_resolution.py
+++ b/src/nasap_fit_py/simulation/rate_constant_resolution.py
@@ -32,18 +32,31 @@ class ResolvedReaction:
 
 
 def resolve_rate_constants(
-    reactions: Sequence[Reaction],
-    reaction_type_to_rate_constant: Mapping[str, RateConstant],
-) -> Sequence[ResolvedReaction]:
+    reactions: Mapping[str, Reaction],
+    rtype_to_rate_constant: Mapping[str, RateConstant],
+) -> Mapping[str, ResolvedReaction]:
 
-    return [
-        ResolvedReaction(
-            reactant1=r.reactant1,
-            reactant2=r.reactant2,
-            product1=r.product1,
-            product2=r.product2,
-            rate_constant_f=reaction_type_to_rate_constant[r.reaction_type].forward*r.duplicate_count_f,
-            rate_constant_b=reaction_type_to_rate_constant[r.reaction_type].backward*r.duplicate_count_b,
+    resolved_reactions = {}
+    for rid, r in reactions.items():
+        if r.reaction_type not in rtype_to_rate_constant:
+            reaction_desc = f"{r.reactant1}"
+            if r.reactant2:
+                reaction_desc += f" + {r.reactant2}"
+            reaction_desc += " -> "
+            reaction_desc += f"{r.product1}"
+            if r.product2:
+                reaction_desc += f" + {r.product2}"
+            raise ValueError(
+                f"Reaction type '{r.reaction_type}' is not defined in rate_constants. "
+                "This is the corresponding reaction. "
+                f"Reaction[{rid}]: {reaction_desc}. "
+            )
+        resolved_reactions[rid] = ResolvedReaction(
+                reactant1=r.reactant1,
+                reactant2=r.reactant2,
+                product1=r.product1,
+                product2=r.product2,
+                rate_constant_f=rtype_to_rate_constant[r.reaction_type].forward*r.duplicate_count_f,
+                rate_constant_b=rtype_to_rate_constant[r.reaction_type].backward*r.duplicate_count_b,
         )
-        for r in reactions
-    ]
+    return resolved_reactions

--- a/src/nasap_fit_py/simulation/tests/test_rate_constant_resolution.py
+++ b/src/nasap_fit_py/simulation/tests/test_rate_constant_resolution.py
@@ -4,96 +4,10 @@ from nasap_fit_py.simulation.rate_constant_resolution import (
     RateConstant, Reaction, ResolvedReaction, resolve_rate_constants)
 
 
-def test_single_reaction_basic(self):
+def test_single_reaction_basic():
     # A + B <-> C + D, with forward rate constant 0.5 and backward rate constant 0.1
-    reactions = [
-        Reaction(
-            reactant1="A",
-            reactant2="B",
-            product1="C",
-            product2="D",
-            reaction_type="type1",
-            duplicate_count_f=1,
-            duplicate_count_b=1,
-        )
-    ]
-    rate_constants = {
-        "type1": RateConstant(forward=0.5, backward=0.1),
-    }
-
-    result = resolve_rate_constants(reactions, rate_constants)
-
-    assert result == [ResolvedReaction(
-        reactant1="A",
-        reactant2="B",
-        product1="C",
-        product2="D",
-        rate_constant_f=0.5,
-        rate_constant_b=0.1,
-    )]
-
-
-def test_single_reaction_with_none_values(self):
-    # A <-> B, with forward rate constant 1.0 and backward rate constant 0.5
-    reactions = [
-        Reaction(
-            reactant1="A",
-            reactant2=None,
-            product1="B",
-            product2=None,
-            reaction_type="unimolecular",
-            duplicate_count_f=1,
-            duplicate_count_b=1,
-        )
-    ]
-    rate_constants = {
-        "unimolecular": RateConstant(forward=1.0, backward=0.5),
-    }
-
-    result = resolve_rate_constants(reactions, rate_constants)
-
-    assert result == [ResolvedReaction(
-        reactant1="A",
-        reactant2=None,
-        product1="B",
-        product2=None,
-        rate_constant_f=1.0,
-        rate_constant_b=0.5,
-    )]
-
-def test_duplicate_count_affects_rate_constants(self):
-    # A + B <-> C + D, with forward rate constant 0.5 and backward rate constant 0.1, and duplicate counts of 3 and 2
-    reactions = [
-        Reaction(
-            reactant1="A",
-            reactant2="B",
-            product1="C",
-            product2="D",
-            reaction_type="type1",
-            duplicate_count_f=3,
-            duplicate_count_b=2,
-        )
-    ]
-    rate_constants = {
-        "type1": RateConstant(forward=0.5, backward=0.1),
-    }
-
-    result = resolve_rate_constants(reactions, rate_constants)
-
-    assert result == [ResolvedReaction(
-        reactant1="A",
-        reactant2="B",
-        product1="C",
-        product2="D",
-        rate_constant_f=1.5,  # 0.5 * 3
-        rate_constant_b=0.2,  # 0.1 * 2
-    )]
-
-def test_multiple_reactions_different_types(self):
-    # A + B <-> C + D (type1), with forward rate constant 0.5 and backward rate constant 0.1
-    # B + C <-> D + E (type2), with forward rate constant 1.0 and backward rate constant 0.2
-    reactions = [
-        Reaction(
+    reactions = {
+        "r1": Reaction(
             reactant1="A",
             reactant2="B",
             product1="C",
@@ -102,7 +16,96 @@ def test_multiple_reactions_different_types(self):
             duplicate_count_f=1,
             duplicate_count_b=1,
         ),
-        Reaction(
+    }
+    rate_constants = {
+        "type1": RateConstant(forward=0.5, backward=0.1),
+    }
+
+    result = resolve_rate_constants(reactions, rate_constants)
+
+    assert result == {
+        "r1": ResolvedReaction(
+        reactant1="A",
+        reactant2="B",
+        product1="C",
+        product2="D",
+        rate_constant_f=0.5,
+        rate_constant_b=0.1,
+    )}
+
+
+def test_single_reaction_with_none_values():
+    # A <-> B, with forward rate constant 1.0 and backward rate constant 0.5
+    reactions = {
+        "r1": Reaction(
+            reactant1="A",
+            reactant2=None,
+            product1="B",
+            product2=None,
+            reaction_type="unimolecular",
+            duplicate_count_f=1,
+            duplicate_count_b=1,
+        ),
+    }
+    rate_constants = {
+        "unimolecular": RateConstant(forward=1.0, backward=0.5),
+    }
+
+    result = resolve_rate_constants(reactions, rate_constants)
+
+    assert result == {
+        "r1": ResolvedReaction(
+        reactant1="A",
+        reactant2=None,
+        product1="B",
+        product2=None,
+        rate_constant_f=1.0,
+        rate_constant_b=0.5,
+    )}
+
+def test_duplicate_count_affects_rate_constants():
+    # A + B <-> C + D, with forward rate constant 0.5 and backward rate constant 0.1, and duplicate counts of 3 and 2
+    reactions = {
+        "r1": Reaction(
+            reactant1="A",
+            reactant2="B",
+            product1="C",
+            product2="D",
+            reaction_type="type1",
+            duplicate_count_f=3,
+            duplicate_count_b=2,
+        ),
+    }
+    rate_constants = {
+        "type1": RateConstant(forward=0.5, backward=0.1),
+    }
+
+    result = resolve_rate_constants(reactions, rate_constants)
+
+    assert result == {
+        "r1": ResolvedReaction(
+        reactant1="A",
+        reactant2="B",
+        product1="C",
+        product2="D",
+        rate_constant_f=1.5,  # 0.5 * 3
+        rate_constant_b=0.2,  # 0.1 * 2
+    )}
+
+def test_multiple_reactions_different_types():
+    # A + B <-> C + D (type1), with forward rate constant 0.5 and backward rate constant 0.1
+    # B + C <-> D + E (type2), with forward rate constant 1.0 and backward rate constant 0.2
+    reactions = {
+        "r1": Reaction(
+            reactant1="A",
+            reactant2="B",
+            product1="C",
+            product2="D",
+            reaction_type="type1",
+            duplicate_count_f=1,
+            duplicate_count_b=1,
+        ),
+        "r2": Reaction(
             reactant1="B",
             reactant2="C",
             product1="D",
@@ -111,7 +114,7 @@ def test_multiple_reactions_different_types(self):
             duplicate_count_f=1,
             duplicate_count_b=1,
         ),
-    ]
+    }
     rate_constants = {
         "type1": RateConstant(forward=0.5, backward=0.1),
         "type2": RateConstant(forward=1.0, backward=0.2),
@@ -119,18 +122,109 @@ def test_multiple_reactions_different_types(self):
 
     result = resolve_rate_constants(reactions, rate_constants)
 
-    assert result == [ResolvedReaction(
+    assert result == {
+        "r1": ResolvedReaction(
         reactant1="A",
         reactant2="B",
         product1="C",
         product2="D",
         rate_constant_f=0.5,
         rate_constant_b=0.1,
-    ), ResolvedReaction(
+    ), 
+        "r2": ResolvedReaction(
         reactant1="B",
         reactant2="C",
         product1="D",
         product2="E",
         rate_constant_f=1.0,
         rate_constant_b=0.2,
-    )]
+    )}
+
+
+def test_undefined_reaction_type_raises_value_error():
+    # Test that an undefined reaction type raises a ValueError with helpful message
+    reactions = {
+        "r1": Reaction(
+            reactant1="A",
+            reactant2="B",
+            product1="C",
+            product2="D",
+            reaction_type="undefined_type",
+            duplicate_count_f=1,
+            duplicate_count_b=1,
+        ),
+    }
+    rate_constants = {
+        "type1": RateConstant(forward=0.5, backward=0.1),
+        "type2": RateConstant(forward=1.0, backward=0.2),
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        resolve_rate_constants(reactions, rate_constants)
+
+    assert str(exc_info.value) == (
+        "Reaction type 'undefined_type' is not defined in rate_constants. "
+        "This is the corresponding reaction. "
+        "Reaction[r1]: A + B -> C + D. "
+    )
+
+
+def test_undefined_reaction_type_unimolecular_empty_rate_constants():
+    # Test that error message correctly shows unimolecular reactions
+    reactions = {
+        "r1": Reaction(
+            reactant1="A",
+            reactant2=None,
+            product1="B",
+            product2=None,
+            reaction_type="unknown_uni",
+            duplicate_count_f=1,
+            duplicate_count_b=1,
+        ),
+    }
+    rate_constants = {}
+
+    with pytest.raises(ValueError) as exc_info:
+        resolve_rate_constants(reactions, rate_constants)
+
+    assert str(exc_info.value) == (
+        "Reaction type 'unknown_uni' is not defined in rate_constants. "
+        "This is the corresponding reaction. "
+        "Reaction[r1]: A -> B. "
+    )
+
+
+def test_undefined_reaction_type_in_second_reaction():
+    # Test that error message correctly identifies which reaction in a list has the undefined type
+    reactions = {
+        "r1": Reaction(
+            reactant1="A",
+            reactant2="B",
+            product1="C",
+            product2="D",
+            reaction_type="type1",
+            duplicate_count_f=1,
+            duplicate_count_b=1,
+        ),
+        "r2": Reaction(
+            reactant1="E",
+            reactant2="F",
+            product1="G",
+            product2="H",
+            reaction_type="undefined_type",
+            duplicate_count_f=1,
+            duplicate_count_b=1,
+        ),
+    }
+    rate_constants = {
+        "type1": RateConstant(forward=0.5, backward=0.1),
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        resolve_rate_constants(reactions, rate_constants)
+
+    assert str(exc_info.value) == (
+        "Reaction type 'undefined_type' is not defined in rate_constants. "
+        "This is the corresponding reaction. "
+        "Reaction[r2]: E + F -> G + H. "
+    )


### PR DESCRIPTION
closes #63 